### PR TITLE
Remove break statements in switches

### DIFF
--- a/Sources/GryphonLib/KotlinTranslator.swift
+++ b/Sources/GryphonLib/KotlinTranslator.swift
@@ -985,9 +985,6 @@ public class KotlinTranslator {
 		result.append(") {\n")
 
 		for switchCase in switchStatement.cases {
-			guard !switchCase.statements.isEmpty else {
-				continue
-			}
 
 			result.append(increasedIndentation)
 

--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -3081,16 +3081,12 @@ public class RemoveBreaksInSwitchesTranspilationPass: TranspilationPass {
 			cases: newCases.toMutableList()))
 	}
 
-	private func removeBreaksInSwitchCase(_ switchCase: SwitchCase) -> SwitchCase? {
-		if switchCase.statements.count == 1,
-			let onlyStatement = switchCase.statements.first,
-			onlyStatement is BreakStatement
-		{
-			return nil
+	private func removeBreaksInSwitchCase(_ switchCase: SwitchCase) -> SwitchCase {
+		let statements = switchCase.statements.prefix {
+			!($0 is BreakStatement)
 		}
-		else {
-			return switchCase
-		}
+		switchCase.statements = statements.toMutableList()
+		return switchCase
 	}
 }
 

--- a/Test cases/switches.kt
+++ b/Test cases/switches.kt
@@ -101,4 +101,13 @@ fun main(args: Array<String>) {
 			println(int)
 		}
 	}
+
+	val z: Int = 0
+
+	when (z) {
+		0 -> {
+		}
+		1 -> println(1)
+		else -> println(2)
+	}
 }

--- a/Test cases/switches.swift
+++ b/Test cases/switches.swift
@@ -128,3 +128,16 @@ func f() {
 		name = "More"
 	}
 }
+
+// break
+let z: Int = 0
+switch z {
+case 0:
+	break
+	print(0)
+case 1:
+	print(1)
+	break
+default:
+	print(2)
+}


### PR DESCRIPTION
Fixes #17 

I basically removed statements after `break` - I believe they are technically dead code. Is that what you expected?