### PR TITLE
Custom targets

### DIFF
--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -1719,19 +1719,18 @@ else
 	puts "	Updating Run Script build phase..."
 end
 
-# Set the script we want to run
-if ARGV.length > 1
-	# If we specified a toolchain
-    gryphonBuildPhase.shell_script =
-		"gryphon \\"\(dollarSign){PROJECT_NAME}.xcodeproj\\"" +
-		" \\"\(dollarSign){SRCROOT}/\(SupportingFile.xcFileList.relativePath)\\"" +
-		" --toolchain=\\"" + ARGV[1] + "\\""
-else
-	# If we're using the default toolchain
-    gryphonBuildPhase.shell_script =
-		"gryphon \\"\(dollarSign){PROJECT_NAME}.xcodeproj\\"" +
-		" \\"\(dollarSign){SRCROOT}/\(SupportingFile.xcFileList.relativePath)\\""
+# Create the script we want to run
+
+script = "gryphon \\"\(dollarSign){PROJECT_NAME}.xcodeproj\\"" +
+	" \\"\(dollarSign){SRCROOT}/\(SupportingFile.xcFileList.relativePath)\\""
+
+# Add any other argument directly to the script (dropping the xcode project first)
+for argument in ARGV.slice(1...)
+	puts "	Including " + argument
+    script = script + " " + argument
 end
+
+gryphonBuildPhase.shell_script = script
 
 ####################################################################################################
 # Make the Kotlin target

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -161,6 +161,10 @@ public class Driver {
 					newArguments.append("--verbose")
 				}
 
+				if let target = target {
+					newArguments.append("--target=\(target)")
+				}
+
 				let setupArguments: MutableList = ["setup-xcode"]
 				setupArguments.append(contentsOf: newArguments)
 				_ = try Driver.run(withArguments: setupArguments)
@@ -182,8 +186,7 @@ public class Driver {
 			try createASTDumpsScript(
 				forXcodeProject: xcodeProject,
 				forTarget: target,
-				usingToolchain: toolchain,
-				simulator: nil)
+				usingToolchain: toolchain)
 
 			Compiler.log("Xcode setup successful.")
 			return nil
@@ -531,13 +534,17 @@ public class Driver {
 
 			let swiftVersion = try TranspilationContext.getVersionOfToolchain(toolchain)
 
+			let target = getTarget(inArguments: arguments)
+
 			var astDumpsSucceeded = true
 			var astDumpError: Error? = nil
 			do {
 				try updateASTDumps(
 					forFiles: allSourceFiles,
-					usingXcode: isUsingXcode,
-					usingToolchain: toolchain)
+					forXcodeProject: maybeXcodeProject,
+					forTarget: target,
+					usingToolchain: toolchain,
+					shouldTryToRecoverFromErrors: true)
 				astDumpsSucceeded = true
 			}
 			catch let error {
@@ -560,7 +567,7 @@ public class Driver {
 							"Attempting to update file list...")
 					}
 					else {
-						Compiler.log("Failed to update some AST dump files: " +
+						Compiler.log("Failed to update the AST dump for some files: " +
 							outdatedASTDumpsAfterFirstUpdate.joined(separator: ", ") +
 							". Attempting to update file list...")
 					}
@@ -571,12 +578,11 @@ public class Driver {
 						try createASTDumpsScript(
 							forXcodeProject: xcodeProject,
 							forTarget: getTarget(inArguments: arguments),
-							usingToolchain: toolchain,
-							simulator: nil)
+							usingToolchain: toolchain)
 					}
 					catch let error {
 						Compiler.logError(
-							"Warning - xcodebuild reported an error creating the AST dump " +
+							"Warning - there was an error when creating the AST dump " +
 								"script:\n" +
 								"\(error)\n" +
 								"Trying to update the AST dumps again...")
@@ -584,8 +590,10 @@ public class Driver {
 
 					try updateASTDumps(
 						forFiles: allSourceFiles,
-						usingXcode: isUsingXcode,
-						usingToolchain: toolchain)
+						forXcodeProject: maybeXcodeProject,
+						forTarget: target,
+						usingToolchain: toolchain,
+						shouldTryToRecoverFromErrors: true)
 
 					let outdatedASTDumpsAfterSecondUpdate = outdatedASTDumpFiles(
 						forInputFiles: allSourceFiles,
@@ -776,19 +784,18 @@ public class Driver {
 			containing: SupportingFile.gryphonKotlinLibrary.contents!)
 	}
 
-	/// Calls xcodebuild to create the AST dump script file. If `simulator` is `nil` and xcodebuild
-	/// fails, looks for an installed simulator and tries again recursively.
-	static func createASTDumpsScript(
+	/// Calls xcodebuild with the given arguments
+	static func runXcodebuild(
 		forXcodeProject xcodeProjectPath: String,
 		forTarget target: String?,
 		usingToolchain toolchain: String?,
-		simulator: String?)
-		throws
+		simulator: String? = nil,
+		dryRun: Bool)
+		-> Shell.CommandOutput
 	{
 		let arguments: MutableList = [
 			"xcodebuild",
 			"-UseModernBuildSystem=NO",
-			"-dry-run",
 			"-project",
 			"\(xcodeProjectPath)", ]
 
@@ -807,58 +814,112 @@ public class Driver {
 			arguments.append("iphonesimulator\(simulatorVersion)")
 		}
 
+		if dryRun {
+			arguments.append("-dry-run")
+		}
+
 		let commandResult = Shell.runShellCommand(arguments)
 
-		// If something went wrong
+		// If something went wrong, try to recover
 		if commandResult.status != 0 {
 			// Code signing errors might be solved by forcing a build with the simulator
 			if simulator == nil,
 				(commandResult.standardError.contains("Code Signing Error:") ||
 				 commandResult.standardOutput.contains("Code Signing Error:"))
 			{
-				// Try to discover the version of an installed simulator
-				let sdkCommandResult = Shell.runShellCommand(["xcodebuild", "-showsdks"])
-				if sdkCommandResult.status == 0 {
-					let output = sdkCommandResult.standardOutput
-					let outputLines = output.split(withStringSeparator: "\n")
+				if let iOSVersion = lookForSimulatorVersion() {
+					return runXcodebuild(
+						forXcodeProject: xcodeProjectPath,
+						forTarget: target,
+						usingToolchain: toolchain,
+						simulator: iOSVersion,
+						dryRun: dryRun)
+				}
+			}
+		}
 
-					// Valid output lines are of the form:
-					// 	Simulator - iOS 13.4          	-sdk iphonesimulator13.4
-					var maybeiOSVersion: String?
-					for line in outputLines {
-						if line.contains("iphonesimulator") {
-							let components = line.split(withStringSeparator: " ")
-							if let simulatorComponent = components.last {
-								maybeiOSVersion = String(
-									simulatorComponent.dropFirst("iphonesimulator".count))
-							}
-						}
-					}
+		return commandResult
+	}
 
-					if let iOSVersion = maybeiOSVersion {
-						try createASTDumpsScript(
-							forXcodeProject: xcodeProjectPath,
-							forTarget: target,
-							usingToolchain: toolchain,
-							simulator: iOSVersion)
-						return
+	/// Try to discover an installed simulator version using xcodebuild
+	static func lookForSimulatorVersion() -> String? {
+		// Try to discover the version of an installed simulator
+		let sdkCommandResult = Shell.runShellCommand(["xcodebuild", "-showsdks"])
+		if sdkCommandResult.status == 0 {
+			let output = sdkCommandResult.standardOutput
+			let outputLines = output.split(withStringSeparator: "\n")
+
+			// Valid output lines are of the form:
+			// 	Simulator - iOS 13.4          	-sdk iphonesimulator13.4
+			for line in outputLines {
+				if line.contains("iphonesimulator") {
+					let components = line.split(withStringSeparator: " ")
+					if let simulatorComponent = components.last {
+						return String(
+							simulatorComponent.dropFirst("iphonesimulator".count))
 					}
 				}
 			}
+		}
 
-			// If we failed to recover, throw an error
+		return nil
+	}
+
+	/// Calls xcodebuild to create the AST dump script file. If `simulator` is `nil` and xcodebuild
+	/// fails, looks for an installed simulator and tries again recursively.
+	static func createASTDumpsScript(
+		forXcodeProject xcodeProjectPath: String,
+		forTarget target: String?,
+		usingToolchain toolchain: String?)
+		throws
+	{
+		let commandResult = runXcodebuild(
+			forXcodeProject: xcodeProjectPath,
+			forTarget: target,
+			usingToolchain: toolchain,
+			dryRun: true)
+
+		guard commandResult.status == 0 else {
 			throw GryphonError(errorMessage: "Error running xcodebuild:\n" +
 				commandResult.standardOutput +
 				commandResult.standardError)
 		}
 
 		let output = commandResult.standardOutput
-		let buildSteps = output.split(withStringSeparator: "\n\n")
+
+		// If the target depends on other targets, the other targets will be built first. We have
+		// to remove their build commands and keep only the target we chose.
+		let targetContents: String
+		if let userTarget = target {
+			let separator = "=== BUILD TARGET "
+			let components = output.split(withStringSeparator: separator)
+			guard let selectedComponent = components.first(where: { $0.hasPrefix(userTarget) })
+				else
+			{
+				throw GryphonError(errorMessage: "Failed to find build instructions for target " +
+					"\(userTarget) in the xcodebuild output.")
+			}
+			targetContents = selectedComponent
+		}
+		else {
+			targetContents = output
+		}
+
+		let buildSteps = targetContents.split(withStringSeparator: "\n\n")
 		guard let compileSwiftStep =
 			buildSteps.first(where: { $0.hasPrefix("CompileSwiftSources") }) else
 		{
-			throw GryphonError(errorMessage:
-				"Unable to find the Swift compilation command in the Xcode project.")
+			if output.contains("builtin-validationUtility") {
+				throw GryphonError(errorMessage:
+					"Unable to find the Swift compilation command for the Xcode project.\n" +
+						"It's possible the build might be cached.\n" +
+						"Try deleting the \"build\" folder, if there is one, then run Gryphon " +
+						"again.")
+			}
+			else {
+				throw GryphonError(errorMessage:
+					"Unable to find the Swift compilation command in the Xcode project.")
+			}
 		}
 
 		let commands = compileSwiftStep.split(withStringSeparator: "\n")
@@ -944,8 +1005,10 @@ public class Driver {
 
 	static func updateASTDumps(
 		forFiles swiftFiles: List<String>,
-		usingXcode: Bool,
-		usingToolchain toolchain: String?)
+		forXcodeProject xcodeProjectPath: String?,
+		forTarget target: String?,
+		usingToolchain toolchain: String?,
+		shouldTryToRecoverFromErrors: Bool)
 		throws
 	{
 		//// Create the outputFileMap
@@ -985,7 +1048,7 @@ public class Driver {
 		let commandResult: Shell.CommandOutput
 
 		Compiler.log("Calling the Swift compiler...")
-		if usingXcode {
+		if xcodeProjectPath != nil {
 			commandResult = Shell.runShellCommand(
 				["bash", SupportingFile.astDumpsScript.relativePath])
 		}
@@ -1018,6 +1081,46 @@ public class Driver {
 		}
 
 		guard commandResult.status == 0 else {
+			if shouldTryToRecoverFromErrors {
+				// If Swift can't find a framework, try building the project with xcodebuild
+				if let xcodeProjectPath = xcodeProjectPath {
+					let errorLines = commandResult.standardError.split(withStringSeparator: "\n")
+					if errorLines.contains(where: {
+							$0.contains("module.modulemap") &&
+							$0.contains(": error: header '") &&
+							$0.contains("-Swift.h' not found")
+						})
+					{
+						Compiler.log("Error updating the ASTs dumps. It seems one or more " +
+							"dependencies wasn't compiled successfully. " +
+							"Trying to fix it by running xcodebuild without `-dry-run`...")
+						let commandResult = runXcodebuild(
+							forXcodeProject: xcodeProjectPath,
+							forTarget: target,
+							usingToolchain: toolchain,
+							simulator: nil,
+							dryRun: false)
+
+						if commandResult.status != 0 {
+							Compiler.log("Failed. Xcodebuild output:\n" +
+								commandResult.standardOutput +
+								commandResult.standardError)
+						}
+						else {
+							Compiler.log("Success. Trying to update the AST dumps again...")
+							// If it worked, try again, but only once to avoid infinite recursion
+							try updateASTDumps(
+								forFiles: swiftFiles,
+								forXcodeProject: xcodeProjectPath,
+								forTarget: target,
+								usingToolchain: toolchain,
+								shouldTryToRecoverFromErrors: false)
+							return
+						}
+					}
+				}
+			}
+
 			var errorMessage = "Error calling the Swift compiler.\n"
 
 			// Suggest solutions to known problems
@@ -1033,7 +1136,7 @@ public class Driver {
 					"Try running `gryphon init <xcode project>` to fix this problem.\n")
 			}
 
-			errorMessage.append("Swift compiler output:\n\n" +
+			errorMessage.append("====\n\n" +
 				commandResult.standardOutput +
 				commandResult.standardError)
 			throw GryphonError(errorMessage: errorMessage)

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -569,7 +569,13 @@ public class Driver {
 							usingToolchain: toolchain,
 							simulator: nil)
 					}
-					catch { }
+					catch let error {
+						Compiler.logError(
+							"Warning - xcodebuild reported an error creating the AST dump " +
+								"script:\n" +
+								"\(error)\n" +
+								"Trying to update the AST dumps again...")
+					}
 
 					try updateASTDumps(
 						forFiles: allSourceFiles,

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -827,13 +827,20 @@ public class Driver {
 				(commandResult.standardError.contains("Code Signing Error:") ||
 				 commandResult.standardOutput.contains("Code Signing Error:"))
 			{
+				Compiler.log("There was a code signing error when running xcodebuild. " +
+					"Using a simulator might fix it. Looking for an installed simulator...")
 				if let iOSVersion = lookForSimulatorVersion() {
+					Compiler.log("Found a simulator for iOS \(iOSVersion). " +
+						"Calling xcodebuild again...")
 					return runXcodebuild(
 						forXcodeProject: xcodeProjectPath,
 						forTarget: target,
 						usingToolchain: toolchain,
 						simulator: iOSVersion,
 						dryRun: dryRun)
+				}
+				else {
+					Compiler.log("No installed simulators were found.")
 				}
 			}
 		}

--- a/Sources/GryphonLib/SharedUtilities.swift
+++ b/Sources/GryphonLib/SharedUtilities.swift
@@ -220,8 +220,10 @@ extension Utilities {
 		{
 			try Driver.updateASTDumps(
 				forFiles: [SupportingFile.gryphonTemplatesLibrary.relativePath],
-				usingXcode: false,
-				usingToolchain: transpilationContext.toolchainName)
+				forXcodeProject: nil,
+				forTarget: nil,
+				usingToolchain: transpilationContext.toolchainName,
+				shouldTryToRecoverFromErrors: true)
 
 			if Utilities.needsToDumpASTForSwiftFiles(
 				[SupportingFile.gryphonTemplatesLibrary.name],

--- a/Tests/GryphonLibTests/SharedTestUtilities.swift
+++ b/Tests/GryphonLibTests/SharedTestUtilities.swift
@@ -116,8 +116,10 @@ class TestUtilities {
 				for testFile in testFiles {
 					try Driver.updateASTDumps(
 						forFiles: [testFile],
-						usingXcode: false,
-						usingToolchain: toolchain)
+						forXcodeProject: nil,
+						forTarget: nil,
+						usingToolchain: toolchain,
+						shouldTryToRecoverFromErrors: true)
 				}
 
 				if Utilities.needsToDumpASTForSwiftFiles(


### PR DESCRIPTION
### What's in this pull request?
Adds the `--target=<target name>` argument so users can choose a specific Xcode target to translate (instead of whatever target `xcodebuild` defaults to).
If the argument is passed on `gryphon init` it will also be added to the invocation in the `Gryphon` Xcode target.

### Does this solve an open issue?
Solves #40.

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  - [x] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't).
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).
