### PR TITLE
Improve verbose logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,33 +1,33 @@
 ---
 name: Bug report
-about: Create a report to help us improve
+about: Tell us about a bug so we can fix it
 title: ''
 labels: bug
 assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+<!-- Note: If instead of reporting a bug you're looking for help using Gryphon, you can always send a message [on Twitter](https://twitter.com/gryphonblog). -->
 
-**To Reproduce**
-Steps to reproduce the behavior:
+**Describe the bug**
+What went wrong? What did you expect to happen instead?
+
+**How to reproduce it**
+How can someone else make this bug happen in their computer?
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
-
-**Screenshots and code snippets**
-If applicable, add screenshots or code snippets to help explain your problem.
-
 **Your environment (please complete the following information):**
  - OS: [e.g. macOS, Linux, Docker]
  - Gryphon version: [e.g. version 0.5.1]
 
-**Additional context**
-Add any other context about the problem here.
+**Screenshots and code snippets**
+If you want to, add screenshots or code snippets to help explain your problem.
 
-Remember: If you just need help using Gryphon, try sending a message [on Twitter](https://twitter.com/gryphonblog) instead.
+**Bonus: Gryphon's verbose output**
+The `--verbose` option makes Gryphon print a lot of information that may help the maintainers find out what went wrong.
+- If the bug happened while running Gryphon from the command line, you can try running it again with the `--verbose` option and including the output in your report.
+- If you're running Gryphon from Xcode, this output can be found by pressing **⌘+9** and selecting the topmost "build" report under the Gryphon target:
+	![Where to find the verbose output on Xcode](https://vinivendra.github.io/Gryphon/assets/images/other/verboseExample.png)

--- a/Bootstrap/Shell.kt
+++ b/Bootstrap/Shell.kt
@@ -36,6 +36,8 @@ public class Shell {
             currentFolder: String? = null)
             : CommandOutput
         {
+            Compiler.log("🛠  ${arguments.joinToString(separator = " ")}")
+
             val commandAndArguments = mutableListOf(command)
             commandAndArguments.addAll(arguments)
 

--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -1727,7 +1727,7 @@ script = "gryphon \\"\(dollarSign){PROJECT_NAME}.xcodeproj\\"" +
 
 # Add any other argument directly to the script (dropping the xcode project first)
 for argument in ARGV.slice(1...)
-	puts "	Including " + argument
+	puts "		Including " + argument
     script = script + " " + argument
 end
 

--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -1722,7 +1722,8 @@ end
 # Create the script we want to run
 
 script = "gryphon \\"\(dollarSign){PROJECT_NAME}.xcodeproj\\"" +
-	" \\"\(dollarSign){SRCROOT}/\(SupportingFile.xcFileList.relativePath)\\""
+	" \\"\(dollarSign){SRCROOT}/\(SupportingFile.xcFileList.relativePath)\\"" +
+	" --verbose"
 
 # Add any other argument directly to the script (dropping the xcode project first)
 for argument in ARGV.slice(1...)

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -87,6 +87,11 @@ public class Driver {
 		withArguments arguments: List<String>)
 		throws -> Any?
 	{
+		let isVerbose = arguments.contains("--verbose")
+		Compiler.shouldLogProgress = isVerbose
+
+		Compiler.log("ℹ️  Gryphon - version \(gryphonVersion)")
+
 		let badArguments = unsupportedArguments(in: arguments)
 		if !badArguments.isEmpty {
 			let argumentsString = badArguments.map { "\"\($0)\"" }.joined(separator: ", ")
@@ -106,9 +111,6 @@ public class Driver {
 			printVersion()
 			return nil
 		}
-
-		let isVerbose = arguments.contains("--verbose")
-		Compiler.shouldLogProgress = isVerbose
 
 		if arguments.contains("clean") {
 

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -108,11 +108,13 @@ public class Driver {
 		}
 
 		let isVerbose = arguments.contains("--verbose")
-		Compiler.shouldLogProgress(if: isVerbose)
+		Compiler.shouldLogProgress = isVerbose
 
 		if arguments.contains("clean") {
+
+			Compiler.logStart("🧑‍💻  Deleting Gryphon files...")
 			cleanup()
-			Compiler.log("Cleanup successful.")
+			Compiler.logEnd("✅  Done deleting Gryphon files.")
 
 			if !arguments.contains("init") {
 				return nil
@@ -120,10 +122,14 @@ public class Driver {
 		}
 
 		if arguments.contains("generate-libraries") {
+			Compiler.logStart("🧑‍💻  Generating libraries...")
 			try generateLibraries()
-			Compiler.log("Generated Gryphon libraries.")
+			Compiler.logEnd("✅  Done generating libraries.")
+
 			return nil
 		}
+
+		Compiler.logStart("🧑‍💻  Checking Xcode arguments...")
 
 		// Get the chosen toolchain, if there is one
 		let toolchain: String?
@@ -139,26 +145,39 @@ public class Driver {
 		else {
 			toolchain = nil
 		}
+
+		Compiler.logStart("🧑‍💻  Checking toolchain support...")
 		try TranspilationContext.checkToolchainSupport(toolchain)
+		let swiftVersion = try TranspilationContext.getVersionOfToolchain(toolchain)
+		Compiler.logEnd("✅  Done checking.")
 
 		if let chosenToolchain = toolchain {
-			Compiler.log("ℹ️\tUsing toolchain \(chosenToolchain).")
+			Compiler.log(
+				"ℹ️  Using toolchain \(chosenToolchain) with Swift \(swiftVersion).")
 		}
 		else {
-			Compiler.log("ℹ️\tUsing default toolchain.")
+			Compiler.log("ℹ️  Using default toolchain with Swift \(swiftVersion).")
 		}
 
 		// Get the chosen target, if there is one
 		let target = getTarget(inArguments: arguments)
 		if let chosenTarget = target {
-			Compiler.log("ℹ️\tUsing target \(chosenTarget).")
+			Compiler.log("ℹ️  Using target \(chosenTarget).")
 		}
 		else {
-			Compiler.log("ℹ️\tUsing default target.")
+			Compiler.log("ℹ️  Using default target.")
 		}
 
-		//
+		// Get the Xcode project, if there is one
 		let maybeXcodeProject = getXcodeProject(inArguments: arguments)
+		if let xcodeProject = maybeXcodeProject {
+			Compiler.log("ℹ️  Using Xcode project \(xcodeProject).")
+		}
+		else {
+			Compiler.log("ℹ️  Not using Xcode.")
+		}
+
+		Compiler.logEnd("✅  Done checking Xcode arguments.")
 
 		if arguments.contains("init") {
 			// The `-xcode` flag forces the initialization to add Xcode files to the
@@ -167,9 +186,8 @@ public class Driver {
 			let shouldInitializeXcodeFiles = (maybeXcodeProject != nil) ||
 				arguments.contains("-xcode")
 
+			Compiler.logStart("🧑‍💻  Initializing...")
 			try initialize(includingXcodeFiles: shouldInitializeXcodeFiles)
-
-			Compiler.log("✅ Initialization successful.")
 
 			if let xcodeProject = maybeXcodeProject {
 				let newArguments: MutableList = [xcodeProject]
@@ -194,6 +212,7 @@ public class Driver {
 				_ = try Driver.run(withArguments: makeTargetArguments)
 			}
 
+			Compiler.logEnd("✅  Done initializing.")
 			return nil
 		}
 
@@ -203,12 +222,15 @@ public class Driver {
 					"Please specify an Xcode project when using `setup-xcode`.")
 			}
 
+			Compiler.logStart("🧑‍💻  Creating AST dump script...")
+
 			try createASTDumpsScript(
 				forXcodeProject: xcodeProject,
 				forTarget: target,
 				usingToolchain: toolchain)
 
-			Compiler.log("✅ Xcode setup successful.")
+			Compiler.logEnd("✅  Done creating AST dump script.")
+
 			return nil
 		}
 		if arguments.contains("make-gryphon-targets") {
@@ -217,24 +239,34 @@ public class Driver {
 					"Please specify an Xcode project when using `make-gryphon-targets`.")
 			}
 
+			Compiler.logStart("🧑‍💻  Adding Gryphon targets to Xcode...")
+
 			try makeGryphonTargets(
 				forXcodeProject: xcodeProject,
 				forTarget: target,
 				usingToolchain: toolchain)
-			Compiler.log("✅ Gryphon target creation successful.")
+
+			Compiler.logEnd("✅  Done adding Gryphon targets.")
+
 			return nil
 		}
 
 		// If there's no build folder, create one, perform the transpilation, then delete it
 		if !Utilities.fileExists(at: SupportingFile.gryphonBuildFolder) {
-			return try performCompilationWithTemporaryBuildFolder(
+			Compiler.logStart("🧑‍💻  Starting compilation with temporary build folder...")
+			let result = try performCompilationWithTemporaryBuildFolder(
 				withArguments: arguments,
 				usingToolchain: toolchain)
+			Compiler.logEnd("✅  Done compilation with temporary build folder")
+			return result
 		}
 		else {
-			return try performCompilation(
+			Compiler.logStart("🧑‍💻  Starting compilation...")
+			let result = try performCompilation(
 				withArguments: arguments,
 				usingToolchain: toolchain)
+			Compiler.logEnd("✅  Done compilation.")
+			return result
 		}
 	}
 
@@ -244,10 +276,14 @@ public class Driver {
 		onFile inputFilePath: String)
 		throws -> Any?
 	{
+		let inputFileRelativePath = Utilities.getRelativePath(forFile: inputFilePath)
+
 		guard settings.shouldGenerateSwiftAST else {
+			Compiler.logStart("☑️  Nothing to do for \(inputFileRelativePath).")
 			return [] // gryphon value: listOf<Any>()
 		}
 
+		Compiler.logStart("🧑‍💻  Reading AST dump file for \(inputFileRelativePath)...")
 		let swiftASTDumpFile = SupportingFile.pathOfSwiftASTDumpFile(
 			forSwiftFile: inputFilePath,
 			swiftVersion: context.swiftVersion)
@@ -261,12 +297,15 @@ public class Driver {
 				"Error reading the AST for file \(inputFilePath). " +
 				"Running `gryphon init` or `gryphon init <xcode_project>` might fix this issue.")
 		}
+		Compiler.logEnd("✅  Done reading AST dump for \(inputFileRelativePath).")
 
-		// Generate the Swift AST
+		Compiler.logStart("🧑‍💻  Generating the Swift AST for \(inputFileRelativePath)...")
 		let swiftAST = try Compiler.generateSwiftAST(fromASTDump: swiftASTDump)
+		Compiler.logEnd("✅  Done generating Swift AST for \(inputFileRelativePath).")
 
 		guard settings.shouldGenerateRawAST else {
 			if settings.shouldEmitSwiftAST, !settings.quietModeIsOn {
+				Compiler.log("✍️  Printing Swift AST for \(inputFileRelativePath):")
 				let output = swiftAST.prettyDescription()
 				Compiler.output(output)
 			}
@@ -276,19 +315,23 @@ public class Driver {
 
 		let isMainFile = (inputFilePath == settings.mainFilePath)
 
+		Compiler.logStart("🧑‍💻  Generating the raw AST for \(inputFileRelativePath)...")
 		let gryphonRawAST = try Compiler.generateGryphonRawAST(
 			fromSwiftAST: swiftAST,
 			asMainFile: isMainFile,
 			withContext: context)
+		Compiler.logEnd("✅  Done generating raw ASt for \(inputFileRelativePath).")
 
 		if settings.shouldEmitSwiftAST {
 			let output = swiftAST.prettyDescription()
 			if let outputFilePath = gryphonRawAST.outputFileMap[.swiftAST],
 				!settings.forcePrintingToConsole
 			{
+				Compiler.log("✍️  Writing Swift AST to file for \(inputFileRelativePath)")
 				try Utilities.createFile(atPath: outputFilePath, containing: output)
 			}
 			else if !settings.quietModeIsOn {
+				Compiler.log("✍️  Printing Swift AST for \(inputFileRelativePath):")
 				Compiler.output(output)
 			}
 		}
@@ -298,9 +341,11 @@ public class Driver {
 			if let outputFilePath = gryphonRawAST.outputFileMap[.gryphonASTRaw],
 				!settings.forcePrintingToConsole
 			{
+				Compiler.log("✍️  Writing raw AST to file for \(inputFileRelativePath)")
 				try Utilities.createFile(atPath: outputFilePath, containing: output)
 			}
 			else if !settings.quietModeIsOn {
+				Compiler.log("✍️  Printing raw AST for \(inputFileRelativePath):")
 				Compiler.output(output)
 			}
 		}
@@ -309,9 +354,11 @@ public class Driver {
 			return gryphonRawAST
 		}
 
+		Compiler.logStart("🧑‍💻  Running first passes on AST for \(inputFileRelativePath)...")
 		let gryphonFirstPassedAST = try Compiler.generateGryphonASTAfterFirstPasses(
 			fromGryphonRawAST: gryphonRawAST,
 			withContext: context)
+		Compiler.logEnd("✅  Done running first passes on AST for \(inputFileRelativePath).")
 
 		return gryphonFirstPassedAST
 	}
@@ -323,16 +370,23 @@ public class Driver {
 		onFile inputFilePath: String)
 		throws -> Any?
 	{
+		let inputFileRelativePath = Utilities.getRelativePath(forFile: inputFilePath)
+
+		Compiler.logStart("🧑‍💻  Running second passes on AST for \(inputFileRelativePath)...")
 		let gryphonAST = try Compiler.generateGryphonASTAfterSecondPasses(
 			fromGryphonRawAST: gryphonFirstPassedAST, withContext: context)
+		Compiler.logEnd("✅  Done running second passes on AST for \(inputFileRelativePath).")
+
 		if settings.shouldEmitAST {
 			let output = gryphonAST.prettyDescription()
 			if let outputFilePath = gryphonAST.outputFileMap[.gryphonAST],
 				!settings.forcePrintingToConsole
 			{
+				Compiler.log("✍️  Writing AST to file for \(inputFileRelativePath)")
 				try Utilities.createFile(atPath: outputFilePath, containing: output)
 			}
 			else if !settings.quietModeIsOn {
+				Compiler.log("✍️  Printing AST for \(inputFileRelativePath):")
 				Compiler.output(output)
 			}
 		}
@@ -341,23 +395,28 @@ public class Driver {
 			return gryphonAST
 		}
 
+		Compiler.logStart("🧑‍💻  Generating Kotlin code for \(inputFileRelativePath)...")
 		let kotlinCode = try Compiler.generateKotlinCode(
 			fromGryphonAST: gryphonAST,
 			withContext: context)
+		Compiler.logEnd("✅  Done generating Kotlin code for \(inputFileRelativePath).")
+
 		if settings.shouldEmitKotlin {
 			if settings.forcePrintingToConsole {
 				if !settings.quietModeIsOn {
+					Compiler.log("✍️  Printing Kotlin code for \(inputFileRelativePath):")
 					Compiler.output(kotlinCode)
 				}
 			}
 			else {
 				if let outputFilePath = gryphonAST.outputFileMap[.kt] {
-					let absoluteFilePath = Utilities.getAbsoultePath(forFile: outputFilePath)
-					Compiler.log("Writing to file \(absoluteFilePath)")
+					Compiler.log("✍️  Writing Kotlin to file for \(inputFileRelativePath)")
 					try Utilities.createFile(atPath: outputFilePath, containing: kotlinCode)
 				}
 				else {
 					if settings.xcodeProjectPath != nil {
+						Compiler.log("⚠️  No output Kotlin file found for \(inputFileRelativePath)")
+
 						// If the user didn't ask to print to console and we're in Xcode but there's
 						// no output file, it's likely the user forgot to add an output file
 						Compiler.handleWarning(
@@ -370,6 +429,7 @@ public class Driver {
 					}
 
 					if !settings.quietModeIsOn {
+						Compiler.log("✍️  Printing Kotlin code for \(inputFileRelativePath):")
 						Compiler.output(kotlinCode)
 					}
 				}
@@ -427,6 +487,8 @@ public class Driver {
 		usingToolchain toolchain: String?)
 		throws -> Any?
 	{
+		Compiler.logStart("🧑‍💻  Parsing arguments...")
+
 		Compiler.clearIssues()
 
 		// Parse arguments
@@ -489,6 +551,9 @@ public class Driver {
 		let defaultsToFinal = arguments.contains("--default-final")
 
 		//
+		let maybeXcodeProject = getXcodeProject(inArguments: arguments)
+
+		//
 		let settings = Settings(
 			shouldEmitSwiftAST: shouldEmitSwiftAST,
 			shouldEmitRawAST: shouldEmitRawAST,
@@ -501,7 +566,22 @@ public class Driver {
 			forcePrintingToConsole: forcePrintingToConsole,
 			quietModeIsOn: quietModeIsOn,
 			mainFilePath: mainFilePath,
-			xcodeProjectPath: getXcodeProject(inArguments: arguments))
+			xcodeProjectPath: maybeXcodeProject)
+
+		Compiler.logStart("🔧  Using settings:")
+		Compiler.log("ℹ️  shouldEmitSwiftAST: \(shouldEmitSwiftAST)")
+		Compiler.log("ℹ️  shouldEmitRawAST: \(shouldEmitRawAST)")
+		Compiler.log("ℹ️  shouldEmitAST: \(shouldEmitAST)")
+		Compiler.log("ℹ️  shouldEmitKotlin: \(shouldEmitKotlin)")
+		Compiler.log("ℹ️  shouldGenerateKotlin: \(shouldGenerateKotlin)")
+		Compiler.log("ℹ️  shouldGenerateAST: \(shouldGenerateAST)")
+		Compiler.log("ℹ️  shouldGenerateRawAST: \(shouldGenerateRawAST)")
+		Compiler.log("ℹ️  shouldGenerateSwiftAST: \(shouldGenerateSwiftAST)")
+		Compiler.log("ℹ️  forcePrintingToConsole: \(forcePrintingToConsole)")
+		Compiler.log("ℹ️  quietModeIsOn: \(quietModeIsOn)")
+		Compiler.log("ℹ️  mainFilePath: \(mainFilePath ?? "no main file")")
+		Compiler.log("ℹ️  xcodeProjectPath: \(maybeXcodeProject ?? "no Xcode project")")
+		Compiler.logEnd("🔧  Settings done.")
 
 		//
 		var indentationString = "    "
@@ -524,8 +604,12 @@ public class Driver {
 		//
 		let shouldRunConcurrently = !arguments.contains("--sync")
 
+		Compiler.logEnd("✅  Done parsing arguments.")
+
 		//// Dump the ASTs
 		if !arguments.contains("-skip-AST-dumps") {
+			Compiler.logStart("🧑‍💻  Preparing to dump the ASTs...")
+
 			let maybeXcodeProject = getXcodeProject(inArguments: arguments)
 			let isUsingXcode = (maybeXcodeProject != nil)
 			let isSkippingFiles = arguments.contains("--skip")
@@ -559,9 +643,12 @@ public class Driver {
 
 			let target = getTarget(inArguments: arguments)
 
+			Compiler.logEnd("✅  Done perparing.")
+
 			var astDumpsSucceeded = true
 			var astDumpError: Error? = nil
 			do {
+				Compiler.logStart("🧑‍💻  Dumping the ASTs...")
 				try updateASTDumps(
 					forFiles: allSourceFiles,
 					forXcodeProject: maybeXcodeProject,
@@ -569,8 +656,10 @@ public class Driver {
 					usingToolchain: toolchain,
 					shouldTryToRecoverFromErrors: true)
 				astDumpsSucceeded = true
+				Compiler.logEnd("✅  Done dumping the ASTs.")
 			}
 			catch let error {
+				Compiler.logEnd("⚠️  Problem dumping the ASTs.")
 				astDumpsSucceeded = false
 				astDumpError = error
 			}
@@ -579,6 +668,11 @@ public class Driver {
 				forInputFiles: allSourceFiles,
 				swiftVersion: swiftVersion)
 
+			if !outdatedASTDumpsAfterFirstUpdate.isEmpty {
+				Compiler.log("⚠️  Found outdated files: " +
+					outdatedASTDumpsAfterFirstUpdate.joined(separator: ", ") + ".")
+			}
+
 			if !astDumpsSucceeded || !outdatedASTDumpsAfterFirstUpdate.isEmpty {
 				if let xcodeProject = maybeXcodeProject {
 					// If the AST dump update failed and we're using Xcode, it's possible one
@@ -586,11 +680,11 @@ public class Driver {
 					// script, then try to update the files again.
 
 					if outdatedASTDumpsAfterFirstUpdate.isEmpty {
-						Compiler.log("There was an error when with the Swift compiler. " +
+						Compiler.logStart("⚠️  There was an error when with the Swift compiler. " +
 							"Attempting to update file list...")
 					}
 					else {
-						Compiler.log("Failed to update the AST dump for some files: " +
+						Compiler.logStart("⚠️  Failed to update the AST dump for some files: " +
 							outdatedASTDumpsAfterFirstUpdate.joined(separator: ", ") +
 							". Attempting to update file list...")
 					}
@@ -602,14 +696,16 @@ public class Driver {
 							forXcodeProject: xcodeProject,
 							forTarget: getTarget(inArguments: arguments),
 							usingToolchain: toolchain)
+						Compiler.logEnd("⚠️  Done.")
 					}
 					catch let error {
-						Compiler.logError(
-							"Warning - there was an error when creating the AST dump " +
+						Compiler.logEnd(
+							"⚠️  There was an error when creating the AST dump " +
 								"script:\n" +
-								"\(error)\n" +
-								"Trying to update the AST dumps again...")
+								"\(error)\n")
 					}
+
+					Compiler.logStart("⚠️  Attempting to update the AST dumps again...")
 
 					try updateASTDumps(
 						forFiles: allSourceFiles,
@@ -629,6 +725,9 @@ public class Driver {
 								" - Make sure the files are being compiled by Xcode.\n" +
 								" - Make sure Gryphon is translating the right Xcode target " +
 									"using `--target=<target name>`.")
+					}
+					else {
+						Compiler.logEnd("✅  Done.")
 					}
 				}
 				else {
@@ -658,15 +757,17 @@ public class Driver {
 				indentationString: indentationString,
 				defaultsToFinal: defaultsToFinal)
 
-			Compiler.log("Translating source files...\n")
+			Compiler.logStart("🧑‍💻 Starting first part of translation [1/2]...")
 
 			let firstResult: List<Any?>
 			if shouldRunConcurrently {
+				Compiler.log("🔀  Translating concurrently, logs may come out of order.")
 				firstResult = try inputFilePaths.parallelMap {
 					try runUpToFirstPasses(withSettings: settings, withContext: context, onFile: $0)
 				}
 			}
 			else {
+				Compiler.log("⏩  Translating sequentially.")
 				firstResult = try inputFilePaths.map {
 					try runUpToFirstPasses(withSettings: settings, withContext: context, onFile: $0)
 				}
@@ -677,13 +778,18 @@ public class Driver {
 			guard let asts = firstResult.as(List<GryphonAST>.self),
 				settings.shouldGenerateAST else
 			{
+				Compiler.log("✅  Done first part of translation. Returning result.")
 				return firstResult
 			}
+
+			Compiler.logEnd("✅  Done first part of translation.")
+			Compiler.logStart("🧑‍💻 Starting second part translation [2/2]...")
 
 			let pairsArray = zip(asts, inputFilePaths)
 
 			let secondResult: List<Any?>
 			if shouldRunConcurrently {
+				Compiler.log("🔀  Translating concurrently, logs may come out of order.")
 				secondResult = try pairsArray.parallelMap {
 					try runAfterFirstPasses(
 						onAST: $0.0,
@@ -693,6 +799,7 @@ public class Driver {
 				}
 			}
 			else {
+				Compiler.log("⏩  Translating sequentially.")
 				secondResult = try pairsArray.map {
 					try runAfterFirstPasses(
 						onAST: $0.0,
@@ -702,11 +809,18 @@ public class Driver {
 				}
 			}
 
+			Compiler.logEnd("✅  Done second part of translation.")
+			Compiler.logStart("🧑‍💻  Printing issues (if there are any)...")
 			Compiler.printIssues(skippingWarnings: quietModeIsOn)
+			Compiler.logEnd("✅  Done printing issues.")
+
 			return secondResult
 		}
 		catch let error {
+			Compiler.log("⚠️  Something happened.")
+			Compiler.logStart("⚠️  Printing issues (if there are any)...")
 			Compiler.printIssues(skippingWarnings: quietModeIsOn)
+			Compiler.logEnd("⚠️  Done printing issues.")
 			throw error
 		}
 	}
@@ -776,9 +890,11 @@ public class Driver {
 		let filesToInitialize: List<SupportingFile>
 
 		if includingXcodeFiles {
+			Compiler.log("ℹ️  Generating xcode files")
 			filesToInitialize = SupportingFile.filesForXcodeInitialization
 		}
 		else {
+			Compiler.log("ℹ️  Generating basic files only")
 			filesToInitialize = SupportingFile.filesForInitialization
 		}
 
@@ -850,20 +966,23 @@ public class Driver {
 				(commandResult.standardError.contains("Code Signing Error:") ||
 				 commandResult.standardOutput.contains("Code Signing Error:"))
 			{
-				Compiler.log("There was a code signing error when running xcodebuild. " +
-					"Using a simulator might fix it. Looking for an installed simulator...")
+				Compiler.log("⚠️  There was a code signing error when running xcodebuild. " +
+					"Using a simulator might fix it.")
+				Compiler.logStart("⚠️  Looking for an installed simulator...")
 				if let iOSVersion = lookForSimulatorVersion() {
-					Compiler.log("Found a simulator for iOS \(iOSVersion). " +
-						"Calling xcodebuild again...")
-					return runXcodebuild(
+					Compiler.logEnd("⚠️  Found a simulator for iOS \(iOSVersion).")
+					Compiler.logStart("⚠️  Calling xcodebuild again...")
+					let result = runXcodebuild(
 						forXcodeProject: xcodeProjectPath,
 						forTarget: target,
 						usingToolchain: toolchain,
 						simulator: iOSVersion,
 						dryRun: dryRun)
+					Compiler.logEnd("⚠️  Done.")
+					return result
 				}
 				else {
-					Compiler.log("No installed simulators were found.")
+					Compiler.logEnd("⚠️  No installed simulators were found.")
 				}
 			}
 		}
@@ -921,6 +1040,8 @@ public class Driver {
 		// to remove their build commands and keep only the target we chose.
 		let targetContents: String
 		if let userTarget = target {
+			Compiler.log("ℹ️  Looking for build instructions for the \(userTarget) target...")
+
 			let separator = "=== BUILD TARGET "
 			let components = output.split(withStringSeparator: separator)
 			guard let selectedComponent = components.first(where: { $0.hasPrefix(userTarget) })
@@ -935,6 +1056,7 @@ public class Driver {
 			targetContents = output
 		}
 
+		Compiler.log("ℹ️  Looking for Swift compilation command...")
 		let buildSteps = targetContents.split(withStringSeparator: "\n\n")
 		guard let compileSwiftStep =
 			buildSteps.first(where: { $0.hasPrefix("CompileSwiftSources") }) else
@@ -952,6 +1074,7 @@ public class Driver {
 			}
 		}
 
+		Compiler.log("ℹ️  Adapting Swift compilation command for dumping ASTs...")
 		let commands = compileSwiftStep.split(withStringSeparator: "\n")
 
 		// Drop the header and the old compilation command
@@ -990,12 +1113,14 @@ public class Driver {
 		// Build the resulting command
 		result += "\t"
 		if let chosenToolchain = toolchain {
+			Compiler.log("ℹ️  Adding toolchain \(chosenToolchain)...")
 			// Set the toolchain manually by replacing the direct call to swiftc with a call to
 			// xcrun
 			result += "\txcrun -toolchain \"\(chosenToolchain)\" swiftc "
 			result += newComponents.dropFirst().joined(separator: " ")
 		}
 		else {
+			Compiler.log("ℹ️  Using default toolchain...")
 			// Use the default toolchain
 			result += newComponents.joined(separator: " ")
 		}
@@ -1027,6 +1152,7 @@ public class Driver {
 			arguments.append("--target=\"\(userTarget)\"")
 		}
 
+		Compiler.logStart("🧑‍💻  Calling ruby to create the Gryphon targets...\n")
 		let commandResult = Shell.runShellCommand(arguments)
 
 		guard commandResult.status == 0 else {
@@ -1035,11 +1161,11 @@ public class Driver {
 				commandResult.standardError)
 		}
 
-		Compiler.log("👇 Calling ruby to create the Gryphon targets...\n" +
-			commandResult.standardOutput +
-			"👆 Done calling ruby to create the Gryphon targets.")
+		Compiler.log(commandResult.standardOutput)
+		Compiler.logEnd("✅  Done calling ruby.")
 
 		// Create the xcfilelist so the user has an easier time finding it and populating it
+		Compiler.log("ℹ️  Creating xcfilelist.")
 		_ = Utilities.createFileIfNeeded(at: SupportingFile.xcFileList.relativePath)
 	}
 
@@ -1052,6 +1178,7 @@ public class Driver {
 		throws
 	{
 		//// Create the outputFileMap
+		Compiler.log("ℹ️  Creating the output file map.")
 		var outputFileMapContents = "{\n"
 
 		let swiftVersion = try TranspilationContext.getVersionOfToolchain(toolchain)
@@ -1074,6 +1201,7 @@ public class Driver {
 			containing: outputFileMapContents)
 
 		//// Create the necessary folders for the AST dump files
+		Compiler.log("ℹ️  Creating folders for placing the AST dump files.")
 		for swiftFile in swiftFiles {
 			let astDumpPath = SupportingFile.pathOfSwiftASTDumpFile(
 				forSwiftFile: swiftFile,
@@ -1087,12 +1215,15 @@ public class Driver {
 		//// Call the Swift compiler to dump the ASTs
 		let commandResult: Shell.CommandOutput
 
-		Compiler.log("Calling the Swift compiler...")
+		Compiler.logStart("🧑‍💻  Calling the Swift compiler...")
 		if xcodeProjectPath != nil {
+			Compiler.logStart("🧑‍💻  Using the Xcode script...")
 			commandResult = Shell.runShellCommand(
 				["bash", SupportingFile.astDumpsScript.relativePath])
+			Compiler.logEnd("✅  Done using the Xcode script.")
 		}
 		else {
+			Compiler.logStart("🧑‍💻  Using swiftc...")
 			let arguments: MutableList<String> = []
 
 			if OS.osType == .macOS {
@@ -1118,7 +1249,9 @@ public class Driver {
 			}
 
 			commandResult = Shell.runShellCommand(arguments)
+			Compiler.logEnd("✅  Done using swiftc.")
 		}
+		Compiler.logEnd("✅  Done calling the Swift compiler.")
 
 		guard commandResult.status == 0 else {
 			if shouldTryToRecoverFromErrors {
@@ -1131,8 +1264,8 @@ public class Driver {
 							$0.contains("-Swift.h' not found")
 						})
 					{
-						Compiler.log("Error updating the ASTs dumps. It seems one or more " +
-							"dependencies wasn't compiled successfully. " +
+						Compiler.logStart("⚠️ Error updating the ASTs dumps. It seems one or " +
+							"more dependencies wasn't compiled successfully. " +
 							"Trying to fix it by running xcodebuild without `-dry-run`...")
 						let commandResult = runXcodebuild(
 							forXcodeProject: xcodeProjectPath,
@@ -1142,12 +1275,13 @@ public class Driver {
 							dryRun: false)
 
 						if commandResult.status != 0 {
-							Compiler.log("Failed. Xcodebuild output:\n" +
+							Compiler.logEnd("⚠️  Failed. Xcodebuild output:\n" +
 								commandResult.standardOutput +
 								commandResult.standardError)
 						}
 						else {
-							Compiler.log("Success. Trying to update the AST dumps again...")
+							Compiler.logEnd("⚠️  Success running xcodebuild.")
+							Compiler.logStart("⚠️  Trying to update the AST dumps again...")
 							// If it worked, try again, but only once to avoid infinite recursion
 							try updateASTDumps(
 								forFiles: swiftFiles,
@@ -1155,6 +1289,7 @@ public class Driver {
 								forTarget: target,
 								usingToolchain: toolchain,
 								shouldTryToRecoverFromErrors: false)
+							Compiler.logEnd("✅  Success updating the AST dumps.")
 							return
 						}
 					}

--- a/Sources/GryphonLib/SharedUtilities.swift
+++ b/Sources/GryphonLib/SharedUtilities.swift
@@ -213,17 +213,21 @@ extension Utilities {
             // gryphon insert: libraryUpdateLock.release()
         }
 
+		Compiler.logStart("🧑‍💻  Processing the templates library...")
+
 		if Utilities.needsToDumpASTForSwiftFiles(
 			[SupportingFile.gryphonTemplatesLibrary.name],
 			in: SupportingFile.gryphonTemplatesLibrary.folder ?? ".",
 			forSwiftVersion: transpilationContext.swiftVersion)
 		{
+			Compiler.logStart("🧑‍💻  Updating the templates library's AST dump...")
 			try Driver.updateASTDumps(
 				forFiles: [SupportingFile.gryphonTemplatesLibrary.relativePath],
 				forXcodeProject: nil,
 				forTarget: nil,
 				usingToolchain: transpilationContext.toolchainName,
 				shouldTryToRecoverFromErrors: true)
+			Compiler.logEnd("✅  Done updating the templates library's AST dump.")
 
 			if Utilities.needsToDumpASTForSwiftFiles(
 				[SupportingFile.gryphonTemplatesLibrary.name],
@@ -235,6 +239,7 @@ extension Utilities {
 			}
 		}
 
+		Compiler.logStart("🧑‍💻  Transpiling and running passes...")
         let astArray = try Compiler.transpileGryphonRawASTs(
 			fromASTDumpFiles: [
 				SupportingFile.pathOfSwiftASTDumpFile(
@@ -246,8 +251,9 @@ extension Utilities {
 		_ = RecordTemplatesTranspilationPass(
 			ast: ast,
 			context: transpilationContext).run()
+		Compiler.logEnd("✅  Done transpiling and running passes.")
 
-        Compiler.log("\t* Done!")
+		Compiler.logEnd("✅  Done processing the templates library.")
     }
 
 	static internal func needsToDumpASTForSwiftFiles(

--- a/Sources/GryphonLib/Shell.swift
+++ b/Sources/GryphonLib/Shell.swift
@@ -65,6 +65,8 @@ public struct Shell {
 		fromFolder currentFolder: String? = nil)
 		-> CommandOutput
 	{
+		Compiler.log("🛠  \(arguments.joined(separator: " "))")
+
 		let process = Process()
 		let standardOutput = Pipe()
 		let standardError = Pipe()


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Improvements to the logging system when using the `--verbose` flag.

### Does this solve an open issue?
Yeah, it solves issue number #42.

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't).
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).
