### PR TITLE
Support void return on closure

### DIFF
--- a/Sources/GryphonLib/KotlinTranslator.swift
+++ b/Sources/GryphonLib/KotlinTranslator.swift
@@ -2020,7 +2020,9 @@ public class KotlinTranslator {
 	// MARK: - Supporting methods
 
 	internal func translateType(_ typeName: String) -> String {
-		let typeName = typeName.replacingOccurrences(of: "()", with: "Unit")
+		let typeName = typeName
+				.replacingOccurrences(of: "()", with: "Unit")
+				.replacingOccurrences(of: "Void", with: "Unit")
 
 		if typeName.hasSuffix("?") {
 			return translateType(String(typeName.dropLast())) + "?"

--- a/Test cases/closures.kt
+++ b/Test cases/closures.kt
@@ -44,6 +44,9 @@ internal fun g2(a: Int = 0, closure: () -> Int) {
 internal fun f3(closure: () -> Unit) {
 }
 
+internal fun f4(closure: () -> Unit) {
+}
+
 internal fun bar(closure: () -> Int) {
 }
 
@@ -97,6 +100,7 @@ fun main(args: Array<String>) {
 	g1(closure = { 0 })
 	g2(closure = { 0 })
 	f3 { }
+	f4 { }
 	bar {
 			if (true) {
 				return@bar 1

--- a/Test cases/closures.swift
+++ b/Test cases/closures.swift
@@ -76,6 +76,7 @@ g2 { 0 }
 func f3(_ closure: () throws -> ()) { }
 f3 { }
 
+// Test closures witch return Void instead of ()
 func f4(_ closure: () -> Void) { }
 f4 { }
 

--- a/Test cases/closures.swift
+++ b/Test cases/closures.swift
@@ -76,7 +76,7 @@ g2 { 0 }
 func f3(_ closure: () throws -> ()) { }
 f3 { }
 
-// Test closures witch return Void instead of ()
+// Test closures which return Void instead of ()
 func f4(_ closure: () -> Void) { }
 f4 { }
 

--- a/Test cases/closures.swift
+++ b/Test cases/closures.swift
@@ -76,6 +76,9 @@ g2 { 0 }
 func f3(_ closure: () throws -> ()) { }
 f3 { }
 
+func f4(_ closure: () -> Void) { }
+f4 { }
+
 //
 // Test closures with labeled returns
 


### PR DESCRIPTION

### What's in this pull request?
Now closure in swift returning Void are correctly returning Unit in kotlin
### Does this solve an open issue?
Yeah, it solves issue number #47.
