### PR TITLE
Keep parentheses on types

### DIFF
--- a/Sources/GryphonLib/KotlinTranslator.swift
+++ b/Sources/GryphonLib/KotlinTranslator.swift
@@ -2096,7 +2096,7 @@ public class KotlinTranslator {
 				}
 			}
 			else {
-				return translateType(String(typeName.dropFirst().dropLast()))
+				return "(" + translateType(String(typeName.dropFirst().dropLast())) + ")"
 			}
 		}
 		else if typeName.contains(" -> ") {

--- a/Test cases/misc.kt
+++ b/Test cases/misc.kt
@@ -82,4 +82,5 @@ fun main(args: Array<String>) {
 	val array: List<Int> = listOf(1, 2, 3)
 	val arrayIndex: Int? = array.indexOf(1)
 	val bla: Int = 1
+	var foo: (() -> Unit)? = null
 }

--- a/Test cases/misc.swift
+++ b/Test cases/misc.swift
@@ -104,3 +104,6 @@ let arrayIndex = array.firstIndex(of: 1)
 
 // Test Array<Whatever>.ArrayLiteralElement
 let bla: Array<Int>.ArrayLiteralElement = 1
+
+// Test types with parentheses
+var foo: (() -> ())? = nil


### PR DESCRIPTION
### What's in this pull request?
Swift types that include enveloping parentheses are now kept with the parentheses through the Kotlin translation.

### Does this solve an open issue?
Yeah, it solves issue number #49.

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't).
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).
