### PR TITLE
User structured templates

### DIFF
--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -229,6 +229,168 @@ internal let gryphonSwiftLibraryFileContents = """
 // limitations under the License.
 //
 
+// MARK: - Template class declarations
+internal class GRYTemplate { // gryphon ignore
+	static func dot(_ left: GRYTemplate, _ right: String) -> GRYDotTemplate {
+		return GRYDotTemplate(left, right)
+	}
+
+	static func dot(_ left: String, _ right: String) -> GRYDotTemplate {
+		return GRYDotTemplate(GRYLiteralTemplate(string: left), right)
+	}
+
+	static func call(
+		_ function: GRYTemplate,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYCallTemplate
+	{
+		return GRYCallTemplate(function, parameters)
+	}
+
+	static func call(
+		_ function: String,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYCallTemplate
+	{
+		return GRYCallTemplate(function, parameters)
+	}
+}
+
+internal class GRYDotTemplate: GRYTemplate { // gryphon ignore
+	let left: GRYTemplate
+	let right: String
+
+	init(_ left: GRYTemplate, _ right: String) {
+		self.left = left
+		self.right = right
+	}
+}
+
+internal class GRYCallTemplate: GRYTemplate { // gryphon ignore
+	let function: GRYTemplate
+	let parameters: [GRYParameterTemplate]
+
+	init(_ function: GRYTemplate, _ parameters: [GRYParameterTemplate]) {
+		self.function = function
+		self.parameters = parameters
+	}
+
+	//
+	init(_ function: String, _ parameters: [GRYParameterTemplate]) {
+		self.function = GRYLiteralTemplate(string: function)
+		self.parameters = parameters
+	}
+}
+
+internal class GRYParameterTemplate: ExpressibleByStringLiteral { // gryphon ignore
+	let label: String?
+	let template: GRYTemplate
+
+	internal init(_ label: String?, _ template: GRYTemplate) {
+		if let existingLabel = label {
+			if existingLabel == "_" || existingLabel == "" {
+				self.label = nil
+			}
+			else {
+				self.label = label
+			}
+		}
+		else {
+			self.label = label
+		}
+
+		self.template = template
+	}
+
+	required init(stringLiteral: String) {
+		self.label = nil
+		self.template = GRYLiteralTemplate(string: stringLiteral)
+	}
+
+	static func labeledParameter(
+		_ label: String?,
+		_ template: GRYTemplate)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(label, template)
+	}
+
+	static func labeledParameter(
+		_ label: String?,
+		_ template: String)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(label, GRYLiteralTemplate(string: template))
+	}
+
+	static func dot(
+		_ left: GRYTemplate,
+		_ right: String)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYDotTemplate(left, right))
+	}
+
+	static func dot(
+		_ left: String,
+		_ right: String)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYDotTemplate(GRYLiteralTemplate(string: left), right))
+	}
+
+	static func call(
+		_ function: GRYTemplate,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYCallTemplate(function, parameters))
+	}
+
+	static func call(
+		_ function: String,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYCallTemplate(function, parameters))
+	}
+}
+
+internal class GRYLiteralTemplate: GRYTemplate { // gryphon ignore
+	let string: String
+
+	init(string: String) {
+		self.string = string
+	}
+}
+
+internal class GRYConcatenatedTemplate: GRYTemplate { // gryphon ignore
+	let left: GRYTemplate
+	let right: GRYTemplate
+
+	init(left: GRYTemplate, right: GRYTemplate) {
+		self.left = left
+		self.right = right
+	}
+}
+
+internal func + ( // gryphon ignore
+	left: GRYTemplate,
+	right: GRYTemplate)
+	-> GRYConcatenatedTemplate
+{
+	GRYConcatenatedTemplate(left: left, right: right)
+}
+
+internal func + (left: String, right: GRYTemplate) -> GRYConcatenatedTemplate { // gryphon ignore
+	GRYConcatenatedTemplate(left: GRYLiteralTemplate(string: left), right: right)
+}
+
+internal func + (left: GRYTemplate, right: String) -> GRYConcatenatedTemplate { // gryphon ignore
+	GRYConcatenatedTemplate(left: left, right: GRYLiteralTemplate(string: right))
+}
+
+// MARK: - Templates
 // Replacement for Comparable
 private struct _Comparable: Comparable { // gryphon ignore
 	static func < (lhs: _Comparable, rhs: _Comparable) -> Bool {
@@ -270,6 +432,7 @@ private func gryphonTemplates() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// MARK: - Collections
 
 /// According to http://swiftdoc.org/v4.2/type/Array/hierarchy/
 /// (link found via https://www.raywenderlich.com/139591/building-custom-collection-swift)

--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -958,55 +958,55 @@ import Foundation
 
 // MARK: - Define template classes and operators
 
-private class Template { // gryphon ignore
-	static func dot(_ left: Template, _ right: String) -> DotTemplate {
-		return DotTemplate(left, right)
+private class _GRYTemplate { // gryphon ignore
+	static func dot(_ left: _GRYTemplate, _ right: String) -> _GRYDotTemplate {
+		return _GRYDotTemplate(left, right)
 	}
 
-	static func dot(_ left: String, _ right: String) -> DotTemplate {
-		return DotTemplate(LiteralTemplate(string: left), right)
+	static func dot(_ left: String, _ right: String) -> _GRYDotTemplate {
+		return _GRYDotTemplate(_GRYLiteralTemplate(string: left), right)
 	}
 
-	static func call(_ function: Template, _ parameters: [ParameterTemplate]) -> CallTemplate {
-		return CallTemplate(function, parameters)
+	static func call(_ function: _GRYTemplate, _ parameters: [_GRYParameterTemplate]) -> _GRYCallTemplate {
+		return _GRYCallTemplate(function, parameters)
 	}
 
-	static func call(_ function: String, _ parameters: [ParameterTemplate]) -> CallTemplate {
-		return CallTemplate(function, parameters)
+	static func call(_ function: String, _ parameters: [_GRYParameterTemplate]) -> _GRYCallTemplate {
+		return _GRYCallTemplate(function, parameters)
 	}
 }
 
-private class DotTemplate: Template { // gryphon ignore
-	let left: Template
+private class _GRYDotTemplate: _GRYTemplate { // gryphon ignore
+	let left: _GRYTemplate
 	let right: String
 
-	init(_ left: Template, _ right: String) {
+	init(_ left: _GRYTemplate, _ right: String) {
 		self.left = left
 		self.right = right
 	}
 }
 
-private class CallTemplate: Template { // gryphon ignore
-	let function: Template
-	let parameters: [ParameterTemplate]
+private class _GRYCallTemplate: _GRYTemplate { // gryphon ignore
+	let function: _GRYTemplate
+	let parameters: [_GRYParameterTemplate]
 
-	init(_ function: Template, _ parameters: [ParameterTemplate]) {
+	init(_ function: _GRYTemplate, _ parameters: [_GRYParameterTemplate]) {
 		self.function = function
 		self.parameters = parameters
 	}
 
 	//
-	init(_ function: String, _ parameters: [ParameterTemplate]) {
-		self.function = LiteralTemplate(string: function)
+	init(_ function: String, _ parameters: [_GRYParameterTemplate]) {
+		self.function = _GRYLiteralTemplate(string: function)
 		self.parameters = parameters
 	}
 }
 
-private class ParameterTemplate: ExpressibleByStringLiteral { // gryphon ignore
+private class _GRYParameterTemplate: ExpressibleByStringLiteral { // gryphon ignore
 	let label: String?
-	let template: Template
+	let template: _GRYTemplate
 
-	private init(_ label: String?, _ template: Template) {
+	private init(_ label: String?, _ template: _GRYTemplate) {
 		if let existingLabel = label {
 			if existingLabel == "_" || existingLabel == "" {
 				self.label = nil
@@ -1024,35 +1024,35 @@ private class ParameterTemplate: ExpressibleByStringLiteral { // gryphon ignore
 
 	required init(stringLiteral: String) {
 		self.label = nil
-		self.template = LiteralTemplate(string: stringLiteral)
+		self.template = _GRYLiteralTemplate(string: stringLiteral)
 	}
 
-	static func labeledParameter(_ label: String?, _ template: Template) -> ParameterTemplate {
-		return ParameterTemplate(label, template)
+	static func labeledParameter(_ label: String?, _ template: _GRYTemplate) -> _GRYParameterTemplate {
+		return _GRYParameterTemplate(label, template)
 	}
 
-	static func labeledParameter(_ label: String?, _ template: String) -> ParameterTemplate {
-		return ParameterTemplate(label, LiteralTemplate(string: template))
+	static func labeledParameter(_ label: String?, _ template: String) -> _GRYParameterTemplate {
+		return _GRYParameterTemplate(label, _GRYLiteralTemplate(string: template))
 	}
 
-	static func dot(_ left: Template, _ right: String) -> ParameterTemplate {
-		return ParameterTemplate(nil, DotTemplate(left, right))
+	static func dot(_ left: _GRYTemplate, _ right: String) -> _GRYParameterTemplate {
+		return _GRYParameterTemplate(nil, _GRYDotTemplate(left, right))
 	}
 
-	static func dot(_ left: String, _ right: String) -> ParameterTemplate {
-		return ParameterTemplate(nil, DotTemplate(LiteralTemplate(string: left), right))
+	static func dot(_ left: String, _ right: String) -> _GRYParameterTemplate {
+		return _GRYParameterTemplate(nil, _GRYDotTemplate(_GRYLiteralTemplate(string: left), right))
 	}
 
-	static func call(_ function: Template, _ parameters: [ParameterTemplate]) -> ParameterTemplate {
-		return ParameterTemplate(nil, CallTemplate(function, parameters))
+	static func call(_ function: _GRYTemplate, _ parameters: [_GRYParameterTemplate]) -> _GRYParameterTemplate {
+		return _GRYParameterTemplate(nil, _GRYCallTemplate(function, parameters))
 	}
 
-	static func call(_ function: String, _ parameters: [ParameterTemplate]) -> ParameterTemplate {
-		return ParameterTemplate(nil, CallTemplate(function, parameters))
+	static func call(_ function: String, _ parameters: [_GRYParameterTemplate]) -> _GRYParameterTemplate {
+		return _GRYParameterTemplate(nil, _GRYCallTemplate(function, parameters))
 	}
 }
 
-private class LiteralTemplate: Template { // gryphon ignore
+private class _GRYLiteralTemplate: _GRYTemplate { // gryphon ignore
 	let string: String
 
 	init(string: String) {
@@ -1060,26 +1060,26 @@ private class LiteralTemplate: Template { // gryphon ignore
 	}
 }
 
-private class ConcatenatedTemplate: Template { // gryphon ignore
-	let left: Template
-	let right: Template
+private class _GRYConcatenatedTemplate: _GRYTemplate { // gryphon ignore
+	let left: _GRYTemplate
+	let right: _GRYTemplate
 
-	init(left: Template, right: Template) {
+	init(left: _GRYTemplate, right: _GRYTemplate) {
 		self.left = left
 		self.right = right
 	}
 }
 
-private func + (left: Template, right: Template) -> ConcatenatedTemplate { // gryphon ignore
-	ConcatenatedTemplate(left: left, right: right)
+private func + (left: _GRYTemplate, right: _GRYTemplate) -> _GRYConcatenatedTemplate { // gryphon ignore
+	_GRYConcatenatedTemplate(left: left, right: right)
 }
 
-private func + (left: String, right: Template) -> ConcatenatedTemplate { // gryphon ignore
-	ConcatenatedTemplate(left: LiteralTemplate(string: left), right: right)
+private func + (left: String, right: _GRYTemplate) -> _GRYConcatenatedTemplate { // gryphon ignore
+	_GRYConcatenatedTemplate(left: _GRYLiteralTemplate(string: left), right: right)
 }
 
-private func + (left: Template, right: String) -> ConcatenatedTemplate { // gryphon ignore
-	ConcatenatedTemplate(left: left, right: LiteralTemplate(string: right))
+private func + (left: _GRYTemplate, right: String) -> _GRYConcatenatedTemplate { // gryphon ignore
+	_GRYConcatenatedTemplate(left: left, right: _GRYLiteralTemplate(string: right))
 }
 
 // MARK: - Define special types as stand-ins for some protocols and other types
@@ -1154,23 +1154,23 @@ private func gryphonTemplates() {
 
 	// System
 	_ = print(_any)
-	_ = Template.call("println", ["_any"])
+	_ = _GRYTemplate.call("println", ["_any"])
 
 	_ = print(_any, terminator: "")
-	_ = Template.call("print", ["_any"])
+	_ = _GRYTemplate.call("print", ["_any"])
 
 	_ = fatalError(_string)
-	_ = Template.call("println",
+	_ = _GRYTemplate.call("println",
 			["\\\"Fatal error: \(dollarSign)\(kotlinStringInterpolation)\\\""]) +
 		"; " +
-		Template.call("exitProcess", ["-1"])
+		_GRYTemplate.call("exitProcess", ["-1"])
 
 	_ = assert(_bool)
-	_ = Template.call("assert", ["_bool"])
+	_ = _GRYTemplate.call("assert", ["_bool"])
 
 	// Darwin
 	_ = sqrt(_double)
-	_ = Template.call(.dot("Math", "sqrt"), ["_double"])
+	_ = _GRYTemplate.call(.dot("Math", "sqrt"), ["_double"])
 
 	// Numerics
 	_ = Double(_int)
@@ -1193,91 +1193,91 @@ private func gryphonTemplates() {
 
 	// String
 	_ = String(_anyType)
-	_ = Template.call(.dot("_anyType", "toString"), [])
+	_ = _GRYTemplate.call(.dot("_anyType", "toString"), [])
 
 	_ = _anyType.description
-	_ = Template.call(.dot("_anyType", "toString"), [])
+	_ = _GRYTemplate.call(.dot("_anyType", "toString"), [])
 
 	_ = _string.isEmpty
-	_ = Template.call(.dot("_string", "isEmpty"), [])
+	_ = _GRYTemplate.call(.dot("_string", "isEmpty"), [])
 
 	_ = _string.count
-	_ = Template.dot("_string", "length")
+	_ = _GRYTemplate.dot("_string", "length")
 
 	_ = _string.first
-	_ = Template.call(.dot("_string", "firstOrNull"), [])
+	_ = _GRYTemplate.call(.dot("_string", "firstOrNull"), [])
 
 	_ = _string.last
-	_ = Template.call(.dot("_string", "lastOrNull"), [])
+	_ = _GRYTemplate.call(.dot("_string", "lastOrNull"), [])
 
 	_ = Double(_string)
-	_ = Template.call(.dot("_string", "toDouble"), [])
+	_ = _GRYTemplate.call(.dot("_string", "toDouble"), [])
 
 	_ = Float(_string)
-	_ = Template.call(.dot("_string", "toFloat"), [])
+	_ = _GRYTemplate.call(.dot("_string", "toFloat"), [])
 
 	_ = UInt64(_string)
-	_ = Template.call(.dot("_string", "toULong"), [])
+	_ = _GRYTemplate.call(.dot("_string", "toULong"), [])
 
 	_ = Int64(_string)
-	_ = Template.call(.dot("_string", "toLong"), [])
+	_ = _GRYTemplate.call(.dot("_string", "toLong"), [])
 
 	_ = Int(_string)
-	_ = Template.call(.dot("_string", "toIntOrNull"), [])
+	_ = _GRYTemplate.call(.dot("_string", "toIntOrNull"), [])
 
 	_ = _string.dropLast()
-	_ = Template.call(.dot("_string", "dropLast"), ["1"])
+	_ = _GRYTemplate.call(.dot("_string", "dropLast"), ["1"])
 
 	_ = _string.dropLast(_int)
-	_ = Template.call(.dot("_string", "dropLast"), ["_int"])
+	_ = _GRYTemplate.call(.dot("_string", "dropLast"), ["_int"])
 
 	_ = _string.dropFirst()
-	_ = Template.call(.dot("_string", "drop"), ["1"])
+	_ = _GRYTemplate.call(.dot("_string", "drop"), ["1"])
 
 	_ = _string.dropFirst(_int)
-	_ = Template.call(.dot("_string", "drop"), ["_int"])
+	_ = _GRYTemplate.call(.dot("_string", "drop"), ["_int"])
 
 	_ = _string.drop(while: _closure5)
-	_ = Template.call(.dot("_string", "dropWhile"), ["_closure5"])
+	_ = _GRYTemplate.call(.dot("_string", "dropWhile"), ["_closure5"])
 
 	_ = _string.indices
-	_ = Template.dot("_string", "indices")
+	_ = _GRYTemplate.dot("_string", "indices")
 
 	_ = _string.firstIndex(of: _character)!
-	_ = Template.call(.dot("_string", "indexOf"), ["_character"])
+	_ = _GRYTemplate.call(.dot("_string", "indexOf"), ["_character"])
 
 	_ = _string.contains(where: _closure5)
-	_ = "(" + Template.call(.dot("_string", "find"), ["_closure5"]) + " != null)"
+	_ = "(" + _GRYTemplate.call(.dot("_string", "find"), ["_closure5"]) + " != null)"
 
 	_ = _string.firstIndex(of: _character)
-	_ = Template.call(.dot("_string", "indexOrNull"), ["_character"])
+	_ = _GRYTemplate.call(.dot("_string", "indexOrNull"), ["_character"])
 
 	_ = _string.prefix(_int)
-	_ = Template.call(.dot("_string", "substring"), ["0", "_int"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["0", "_int"])
 
 	_ = _string.prefix(upTo: _index)
-	_ = Template.call(.dot("_string", "substring"), ["0", "_index"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["0", "_index"])
 
 	_ = _string[_index...]
-	_ = Template.call(.dot("_string", "substring"), ["_index"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["_index"])
 
 	_ = _string[..<_index]
-	_ = Template.call(.dot("_string", "substring"), ["0", "_index"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["0", "_index"])
 
 	_ = _string[..._index]
-	_ = Template.call(.dot("_string", "substring"), ["0", "_index + 1"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["0", "_index + 1"])
 
 	_ = _string[_index1..<_index2]
-	_ = Template.call(.dot("_string", "substring"), ["_index1", "_index2"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["_index1", "_index2"])
 
 	_ = _string[_index1..._index2]
-	_ = Template.call(.dot("_string", "substring"), ["_index1", "_index2 + 1"])
+	_ = _GRYTemplate.call(.dot("_string", "substring"), ["_index1", "_index2 + 1"])
 
 	_ = String(_substring)
 	_ = "_substring"
 
 	_ = _string.endIndex
-	_ = Template.dot("_string", "length")
+	_ = _GRYTemplate.dot("_string", "length")
 
 	_ = _string.startIndex
 	_ = "0"
@@ -1298,25 +1298,25 @@ private func gryphonTemplates() {
 	_ = "_index + _int"
 
 	_ = _string1.replacingOccurrences(of: _string2, with: _string3)
-	_ = Template.call(.dot("_string1", "replace"), ["_string2", "_string3"])
+	_ = _GRYTemplate.call(.dot("_string1", "replace"), ["_string2", "_string3"])
 
 	_ = _string1.prefix(while: _closure5)
-	_ = Template.call(.dot("_string1", "takeWhile"), ["_closure5"])
+	_ = _GRYTemplate.call(.dot("_string1", "takeWhile"), ["_closure5"])
 
 	_ = _string1.hasPrefix(_string2)
-	_ = Template.call(.dot("_string1", "startsWith"), ["_string2"])
+	_ = _GRYTemplate.call(.dot("_string1", "startsWith"), ["_string2"])
 
 	_ = _string1.hasSuffix(_string2)
-	_ = Template.call(.dot("_string1", "endsWith"), ["_string2"])
+	_ = _GRYTemplate.call(.dot("_string1", "endsWith"), ["_string2"])
 
 	_ = _range.lowerBound
-	_ = Template.dot("_range", "start")
+	_ = _GRYTemplate.dot("_range", "start")
 
 	_ = _range.upperBound
-	_ = Template.dot("_range", "endInclusive")
+	_ = _GRYTemplate.dot("_range", "endInclusive")
 
 	_ = Range<String.Index>(uncheckedBounds: (lower: _index1, upper: _index2))
-	_ = Template.call("IntRange", ["_index1", "_index2"])
+	_ = _GRYTemplate.call("IntRange", ["_index1", "_index2"])
 
 	_ = _string1.append(_string2)
 	_ = "_string1 += _string2"
@@ -1325,55 +1325,55 @@ private func gryphonTemplates() {
 	_ = "_string += _character"
 
 	_ = _string.capitalized
-	_ = Template.call(.dot("_string", "capitalize"), [])
+	_ = _GRYTemplate.call(.dot("_string", "capitalize"), [])
 
 	_ = _string.uppercased()
-	_ = Template.call(.dot("_string", "toUpperCase"), [])
+	_ = _GRYTemplate.call(.dot("_string", "toUpperCase"), [])
 
 	// Character
 	_ = _character.uppercased()
-	_ = Template.call(.dot("_character", "toUpperCase"), [])
+	_ = _GRYTemplate.call(.dot("_character", "toUpperCase"), [])
 
 	// Array
 	_ = _array.append(_any)
-	_ = Template.call(.dot("_array", "add"), ["_any"])
+	_ = _GRYTemplate.call(.dot("_array", "add"), ["_any"])
 
 	_ = _array.insert(_any, at: _int)
-	_ = Template.call(.dot("_array", "add"), ["_int", "_any"])
+	_ = _GRYTemplate.call(.dot("_array", "add"), ["_int", "_any"])
 
 	_ = _arrayOfOptionals.append(nil)
-	_ = Template.call(.dot("_arrayOfOptionals", "add"), ["null"])
+	_ = _GRYTemplate.call(.dot("_arrayOfOptionals", "add"), ["null"])
 
 	_ = _array1.append(contentsOf: _array2)
-	_ = Template.call(.dot("_array1", "addAll"), ["_array2"])
+	_ = _GRYTemplate.call(.dot("_array1", "addAll"), ["_array2"])
 
 	_ = _array1.append(contentsOf: _array3)
-	_ = Template.call(.dot("_array1", "addAll"), ["_array3"])
+	_ = _GRYTemplate.call(.dot("_array1", "addAll"), ["_array3"])
 
 	_ = _array.isEmpty
-	_ = Template.call(.dot("_array", "isEmpty"), [])
+	_ = _GRYTemplate.call(.dot("_array", "isEmpty"), [])
 
 	_ = _strArray.joined(separator: _string)
-	_ = Template.call(
+	_ = _GRYTemplate.call(
 		.dot("_strArray", "joinToString"),
 		[.labeledParameter("separator", "_string")])
 
 	_ = _strArray.joined()
-	_ = Template.call(
+	_ = _GRYTemplate.call(
 		.dot("_strArray", "joinToString"),
 		[.labeledParameter("separator", "\\\"\\\"")])
 
 	_ = _array.count
-	_ = Template.dot("_array", "size")
+	_ = _GRYTemplate.dot("_array", "size")
 
 	_ = _array.indices
-	_ = Template.dot("_array", "indices")
+	_ = _GRYTemplate.dot("_array", "indices")
 
 	_ = _array.startIndex
 	_ = "0"
 
 	_ = _array.endIndex
-	_ = Template.dot("_array", "size")
+	_ = _GRYTemplate.dot("_array", "size")
 
 	_ = _array.index(after: _int)
 	_ = "_int + 1"
@@ -1382,87 +1382,87 @@ private func gryphonTemplates() {
 	_ = "_int - 1"
 
 	_ = _array.first
-	_ = Template.call(.dot("_array", "firstOrNull"), [])
+	_ = _GRYTemplate.call(.dot("_array", "firstOrNull"), [])
 
 	_ = _array.first(where: _closure3)
-	_ = Template.call(.dot("_array", "find"), ["_closure3"])
+	_ = _GRYTemplate.call(.dot("_array", "find"), ["_closure3"])
 
 	_ = _array.last(where: _closure3)
-	_ = Template.call(.dot("_array", "findLast"), ["_closure3"])
+	_ = _GRYTemplate.call(.dot("_array", "findLast"), ["_closure3"])
 
 	_ = _array.last
-	_ = Template.call(.dot("_array", "lastOrNull"), [])
+	_ = _GRYTemplate.call(.dot("_array", "lastOrNull"), [])
 
 	_ = _array.prefix(while: _closure3)
-	_ = Template.call(.dot("_array", "takeWhile"), ["_closure3"])
+	_ = _GRYTemplate.call(.dot("_array", "takeWhile"), ["_closure3"])
 
 	_ = _array.removeFirst()
-	_ = Template.call(.dot("_array", "removeAt"), ["0"])
+	_ = _GRYTemplate.call(.dot("_array", "removeAt"), ["0"])
 
 	_ = _array.remove(at: _int)
-	_ = Template.call(.dot("_array", "removeAt"), ["_int"])
+	_ = _GRYTemplate.call(.dot("_array", "removeAt"), ["_int"])
 
 	_ = _array.removeAll()
 	_ = "_array.clear()"
 
 	_ = _array.dropFirst()
-	_ = Template.call(.dot("_array", "drop"), ["1"])
+	_ = _GRYTemplate.call(.dot("_array", "drop"), ["1"])
 
 	_ = _array.dropLast()
-	_ = Template.call(.dot("_array", "dropLast"), ["1"])
+	_ = _GRYTemplate.call(.dot("_array", "dropLast"), ["1"])
 
 	_ = _array.map(_closure2)
-	_ = Template.call(.dot("_array", "map"), ["_closure2"])
+	_ = _GRYTemplate.call(.dot("_array", "map"), ["_closure2"])
 
 	_ = _array.flatMap(_closure6)
-	_ = Template.call(.dot("_array", "flatMap"), ["_closure6"])
+	_ = _GRYTemplate.call(.dot("_array", "flatMap"), ["_closure6"])
 
 	_ = _array.compactMap(_closure2)
-	_ = Template.call(.dot(.call(.dot("_array", "map"), ["_closure2"]), "filterNotNull"), [])
+	_ = _GRYTemplate.call(.dot(.call(.dot("_array", "map"), ["_closure2"]), "filterNotNull"), [])
 
 	_ = _array.filter(_closure3)
-	_ = Template.call(.dot("_array", "filter"), ["_closure3"])
+	_ = _GRYTemplate.call(.dot("_array", "filter"), ["_closure3"])
 
 	_ = _array.reduce(_any, _closure)
-	_ = Template.call(.dot("_array", "fold"), ["_any", "_closure"])
+	_ = _GRYTemplate.call(.dot("_array", "fold"), ["_any", "_closure"])
 
 	_ = zip(_array1, _array2)
-	_ = Template.call(.dot("_array1", "zip"), ["_array2"])
+	_ = _GRYTemplate.call(.dot("_array1", "zip"), ["_array2"])
 
 	_ = _array.firstIndex(where: _closure3)
-	_ = Template.call(.dot("_array", "indexOfFirst"), ["_closure3"])
+	_ = _GRYTemplate.call(.dot("_array", "indexOfFirst"), ["_closure3"])
 
 	_ = _array.contains(where: _closure3)
-	_ = "(" + Template.call(.dot("_array", "find"), ["_closure3"]) + " != null)"
+	_ = "(" + _GRYTemplate.call(.dot("_array", "find"), ["_closure3"]) + " != null)"
 
 	_ = _comparableArray.sorted()
-	_ = Template.call(.dot("_comparableArray", "sorted"), [])
+	_ = _GRYTemplate.call(.dot("_comparableArray", "sorted"), [])
 
 	_ = _comparableArray.contains(_comparable)
-	_ = Template.call(.dot("_comparableArray", "contains"), ["_comparable"])
+	_ = _GRYTemplate.call(.dot("_comparableArray", "contains"), ["_comparable"])
 
 	_ = _comparableArray.firstIndex(of: _comparable)
-	_ = Template.call(.dot("_comparableArray", "indexOf"), ["_comparable"])
+	_ = _GRYTemplate.call(.dot("_comparableArray", "indexOf"), ["_comparable"])
 
 	// Dictionary
 	_ = _dictionary.count
-	_ = Template.dot("_dictionary", "size")
+	_ = _GRYTemplate.dot("_dictionary", "size")
 
 	_ = _dictionary.isEmpty
-	_ = Template.call(.dot("_dictionary", "isEmpty"), [])
+	_ = _GRYTemplate.call(.dot("_dictionary", "isEmpty"), [])
 
 	_ = _dictionary.map(_closure2)
-	_ = Template.call(.dot("_dictionary", "map"), ["_closure2"])
+	_ = _GRYTemplate.call(.dot("_dictionary", "map"), ["_closure2"])
 
 	// Int
 	_ = Int.max
-	_ = Template.dot("Int", "MAX_VALUE")
+	_ = _GRYTemplate.dot("Int", "MAX_VALUE")
 
 	_ = Int.min
-	_ = Template.dot("Int", "MIN_VALUE")
+	_ = _GRYTemplate.dot("Int", "MIN_VALUE")
 
 	_ = min(_int1, _int2)
-	_ = Template.call(.dot("Math", "min"), ["_int1", "_int2"])
+	_ = _GRYTemplate.call(.dot("Math", "min"), ["_int1", "_int2"])
 
 	_ = _int1..._int2
 	_ = "_int1.._int2"
@@ -1472,11 +1472,11 @@ private func gryphonTemplates() {
 
 	// Double
 	_ = _double1..._double2
-	_ = Template.call(.dot("(_double1)", "rangeTo"), ["_double2"])
+	_ = _GRYTemplate.call(.dot("(_double1)", "rangeTo"), ["_double2"])
 
 	// Optional
 	_ = _optional.map(_closure4)
-	_ = Template.call(.dot("_optional?", "let"), ["_closure4"])
+	_ = _GRYTemplate.call(.dot("_optional?", "let"), ["_closure4"])
 }
 
 """

--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -409,10 +409,10 @@ private func gryphonTemplates() {
 
 	// Templates with an input that references methods defined in this file
 	_ = zip(_array1, _array2)
-	_ = "_array1.zip(_array2)"
+	_ = GRYTemplate.call(.dot("_array1", "zip"), ["_array2"])
 
 	_ = _array1.toList()
-	_ = "_array1.toList()"
+	_ = GRYTemplate.call(.dot("_array1", "toList"), [])
 
 	_ = _array1.appending(_any)
 	_ = "_array1 + _any"
@@ -422,13 +422,14 @@ private func gryphonTemplates() {
 
 	// Templates with an output that references methods defined in the GryphonKotlinLibrary.kt file
 	_ = _string.suffix(from: _index)
-	_ = "_string.suffix(startIndex = _index)"
+	_ = GRYTemplate.call(.dot("_string", "suffix"), [.labeledParameter("startIndex", "_index")])
 
 	_ = _comparableArray.sorted(by: _closure)
-	_ = "_comparableArray.sorted(isAscending = _closure)"
+	_ = GRYTemplate.call(
+		.dot("_comparableArray", "sorted"), [.labeledParameter("isAscending", "_closure")])
 
 	_ = _array1.removeLast()
-	_ = "_array1.removeLast()"
+	_ = GRYTemplate.call(.dot("_array1", "removeLast"), [])
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Sources/GryphonLib/Extensions.swift
+++ b/Sources/GryphonLib/Extensions.swift
@@ -31,13 +31,16 @@ private func gryphonTemplates() {
 	let _bool = true
 
 	_ = _array[safe: _index]
-	_ = "_array.getSafe(_index)"
+	_ = GRYTemplate.call(.dot("_array", "getSafe"), ["_index"])
 
 	_ = _string1.split(separator: _character)
-	_ = "_string1.split(separator = _character)"
+	_ = GRYTemplate.call(.dot("_string1", "split"), [.labeledParameter("separator", "_character")])
 
 	_ = _string1.split(separator: _character, omittingEmptySubsequences: _bool)
-	_ = "_string1.split(separator = _character, omittingEmptySubsequences = _bool)"
+	_ = GRYTemplate.call(
+		.dot("_string1", "split"),
+		[.labeledParameter("separator", "_character"),
+		 .labeledParameter("omittingEmptySubsequences", "_bool")])
 }
 
 // gryphon insert: internal fun String.split(

--- a/Sources/GryphonLib/GryphonSwiftLibrary.swift
+++ b/Sources/GryphonLib/GryphonSwiftLibrary.swift
@@ -196,10 +196,10 @@ private func gryphonTemplates() {
 
 	// Templates with an input that references methods defined in this file
 	_ = zip(_array1, _array2)
-	_ = "_array1.zip(_array2)"
+	_ = GRYTemplate.call(.dot("_array1", "zip"), ["_array2"])
 
 	_ = _array1.toList()
-	_ = "_array1.toList()"
+	_ = GRYTemplate.call(.dot("_array1", "toList"), [])
 
 	_ = _array1.appending(_any)
 	_ = "_array1 + _any"
@@ -209,13 +209,14 @@ private func gryphonTemplates() {
 
 	// Templates with an output that references methods defined in the GryphonKotlinLibrary.kt file
 	_ = _string.suffix(from: _index)
-	_ = "_string.suffix(startIndex = _index)"
+	_ = GRYTemplate.call(.dot("_string", "suffix"), [.labeledParameter("startIndex", "_index")])
 
 	_ = _comparableArray.sorted(by: _closure)
-	_ = "_comparableArray.sorted(isAscending = _closure)"
+	_ = GRYTemplate.call(
+		.dot("_comparableArray", "sorted"), [.labeledParameter("isAscending", "_closure")])
 
 	_ = _array1.removeLast()
-	_ = "_array1.removeLast()"
+	_ = GRYTemplate.call(.dot("_array1", "removeLast"), [])
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Sources/GryphonLib/GryphonSwiftLibrary.swift
+++ b/Sources/GryphonLib/GryphonSwiftLibrary.swift
@@ -16,6 +16,168 @@
 // limitations under the License.
 //
 
+// MARK: - Template class declarations
+internal class GRYTemplate { // gryphon ignore
+	static func dot(_ left: GRYTemplate, _ right: String) -> GRYDotTemplate {
+		return GRYDotTemplate(left, right)
+	}
+
+	static func dot(_ left: String, _ right: String) -> GRYDotTemplate {
+		return GRYDotTemplate(GRYLiteralTemplate(string: left), right)
+	}
+
+	static func call(
+		_ function: GRYTemplate,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYCallTemplate
+	{
+		return GRYCallTemplate(function, parameters)
+	}
+
+	static func call(
+		_ function: String,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYCallTemplate
+	{
+		return GRYCallTemplate(function, parameters)
+	}
+}
+
+internal class GRYDotTemplate: GRYTemplate { // gryphon ignore
+	let left: GRYTemplate
+	let right: String
+
+	init(_ left: GRYTemplate, _ right: String) {
+		self.left = left
+		self.right = right
+	}
+}
+
+internal class GRYCallTemplate: GRYTemplate { // gryphon ignore
+	let function: GRYTemplate
+	let parameters: [GRYParameterTemplate]
+
+	init(_ function: GRYTemplate, _ parameters: [GRYParameterTemplate]) {
+		self.function = function
+		self.parameters = parameters
+	}
+
+	//
+	init(_ function: String, _ parameters: [GRYParameterTemplate]) {
+		self.function = GRYLiteralTemplate(string: function)
+		self.parameters = parameters
+	}
+}
+
+internal class GRYParameterTemplate: ExpressibleByStringLiteral { // gryphon ignore
+	let label: String?
+	let template: GRYTemplate
+
+	internal init(_ label: String?, _ template: GRYTemplate) {
+		if let existingLabel = label {
+			if existingLabel == "_" || existingLabel == "" {
+				self.label = nil
+			}
+			else {
+				self.label = label
+			}
+		}
+		else {
+			self.label = label
+		}
+
+		self.template = template
+	}
+
+	required init(stringLiteral: String) {
+		self.label = nil
+		self.template = GRYLiteralTemplate(string: stringLiteral)
+	}
+
+	static func labeledParameter(
+		_ label: String?,
+		_ template: GRYTemplate)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(label, template)
+	}
+
+	static func labeledParameter(
+		_ label: String?,
+		_ template: String)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(label, GRYLiteralTemplate(string: template))
+	}
+
+	static func dot(
+		_ left: GRYTemplate,
+		_ right: String)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYDotTemplate(left, right))
+	}
+
+	static func dot(
+		_ left: String,
+		_ right: String)
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYDotTemplate(GRYLiteralTemplate(string: left), right))
+	}
+
+	static func call(
+		_ function: GRYTemplate,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYCallTemplate(function, parameters))
+	}
+
+	static func call(
+		_ function: String,
+		_ parameters: [GRYParameterTemplate])
+		-> GRYParameterTemplate
+	{
+		return GRYParameterTemplate(nil, GRYCallTemplate(function, parameters))
+	}
+}
+
+internal class GRYLiteralTemplate: GRYTemplate { // gryphon ignore
+	let string: String
+
+	init(string: String) {
+		self.string = string
+	}
+}
+
+internal class GRYConcatenatedTemplate: GRYTemplate { // gryphon ignore
+	let left: GRYTemplate
+	let right: GRYTemplate
+
+	init(left: GRYTemplate, right: GRYTemplate) {
+		self.left = left
+		self.right = right
+	}
+}
+
+internal func + ( // gryphon ignore
+	left: GRYTemplate,
+	right: GRYTemplate)
+	-> GRYConcatenatedTemplate
+{
+	GRYConcatenatedTemplate(left: left, right: right)
+}
+
+internal func + (left: String, right: GRYTemplate) -> GRYConcatenatedTemplate { // gryphon ignore
+	GRYConcatenatedTemplate(left: GRYLiteralTemplate(string: left), right: right)
+}
+
+internal func + (left: GRYTemplate, right: String) -> GRYConcatenatedTemplate { // gryphon ignore
+	GRYConcatenatedTemplate(left: left, right: GRYLiteralTemplate(string: right))
+}
+
+// MARK: - Templates
 // Replacement for Comparable
 private struct _Comparable: Comparable { // gryphon ignore
 	static func < (lhs: _Comparable, rhs: _Comparable) -> Bool {
@@ -57,6 +219,7 @@ private func gryphonTemplates() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+// MARK: - Collections
 
 /// According to http://swiftdoc.org/v4.2/type/Array/hierarchy/
 /// (link found via https://www.raywenderlich.com/139591/building-custom-collection-swift)

--- a/Sources/GryphonLib/LibraryTranspilationPass.swift
+++ b/Sources/GryphonLib/LibraryTranspilationPass.swift
@@ -48,10 +48,10 @@ public class RecordTemplatesTranspilationPass: TranspilationPass {
 			for templateExpression in topLevelExpressions {
 				if let swiftExpression = previousExpression {
 					if let typeName = templateExpression.swiftType,
-						typeName == "LiteralTemplate" ||
-							typeName == "DotTemplate" ||
-							typeName == "CallTemplate" ||
-							typeName == "ConcatenatedTemplate"
+						typeName == "_GRYLiteralTemplate" ||
+							typeName == "_GRYDotTemplate" ||
+							typeName == "_GRYCallTemplate" ||
+							typeName == "_GRYConcatenatedTemplate"
 					{
 						let processedExpression =
 							processTemplateNodeExpression(templateExpression)

--- a/Sources/GryphonLib/LibraryTranspilationPass.swift
+++ b/Sources/GryphonLib/LibraryTranspilationPass.swift
@@ -51,7 +51,11 @@ public class RecordTemplatesTranspilationPass: TranspilationPass {
 						typeName == "_GRYLiteralTemplate" ||
 							typeName == "_GRYDotTemplate" ||
 							typeName == "_GRYCallTemplate" ||
-							typeName == "_GRYConcatenatedTemplate"
+							typeName == "_GRYConcatenatedTemplate" ||
+							typeName == "GRYLiteralTemplate" ||
+							typeName == "GRYDotTemplate" ||
+							typeName == "GRYCallTemplate" ||
+							typeName == "GRYConcatenatedTemplate"
 					{
 						let processedExpression =
 							processTemplateNodeExpression(templateExpression)

--- a/Sources/GryphonLib/SharedUtilities.swift
+++ b/Sources/GryphonLib/SharedUtilities.swift
@@ -33,65 +33,100 @@ private func gryphonTemplates() throws {
     let _fileExtension1 = FileExtension.swift
 
     _ = Utilities.file(_string1, wasModifiedLaterThan: _string2)
-    _ = "Utilities.fileWasModifiedLaterThan(_string1, _string2)"
+	_ = GRYTemplate.call(.dot("Utilities", "fileWasModifiedLaterThan"), ["_string1", "_string2"])
 
     _ = Utilities.files(_stringArray1, wereModifiedLaterThan: _stringArray2)
-    _ = "Utilities.filesWereModifiedLaterThan(_stringArray1, _stringArray2)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "filesWereModifiedLaterThan"), ["_stringArray1", "_stringArray2"])
 
     _ = try Utilities.createFile(named: _string1, inDirectory: _string2, containing: _string3)
-    _ = "Utilities.createFileAndDirectory(" +
-        "fileName = _string1, directory = _string2, contents = _string3)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "createFileAndDirectory"),
+		[.labeledParameter("fileName", "_string1"),
+		 .labeledParameter("directory", "_string2"),
+		 .labeledParameter("contents", "_string3")])
 
     _ = Utilities.getFiles(_stringArray, inDirectory: _string1, withExtension: _fileExtension1)
-    _ = "Utilities.getFiles(" +
-        "selectedFiles = _stringArray, directory = _string1, fileExtension = _fileExtension1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "getFiles"),
+		[.labeledParameter("selectedFiles", "_stringArray"),
+		 .labeledParameter("directory", "_string1"),
+		 .labeledParameter("fileExtension", "_fileExtension1")])
 
     _ = Utilities.getFiles(inDirectory: _string1, withExtension: _fileExtension1)
-    _ = "Utilities.getFiles(directory = _string1, fileExtension = _fileExtension1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "getFiles"),
+		[.labeledParameter("directory", "_string1"),
+		 .labeledParameter("fileExtension", "_fileExtension1")])
 
     _ = Utilities.getAbsoultePath(forFile: _string1)
-    _ = "Utilities.getAbsoultePath(file = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "getAbsoultePath"),
+		[.labeledParameter("file", "_string1")])
 
 	_ = Utilities.fileExists(at: _string1)
-	_ = "Utilities.fileExists(filePath = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "fileExists"),
+		[.labeledParameter("filePath", "_string1")])
 
     _ = Utilities.createFileIfNeeded(at: _string1)
-    _ = "Utilities.createFileIfNeeded(filePath = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "createFileIfNeeded"),
+		[.labeledParameter("filePath", "_string1")])
 
 	Utilities.createFolderIfNeeded(at: _string1)
-    _ = "Utilities.createFolderIfNeeded(path = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "createFolderIfNeeded"),
+		[.labeledParameter("path", "_string1")])
 
     try Utilities.createFile(atPath: _string1, containing: _string2)
-    _ = "Utilities.createFile(filePath = _string1, contents = _string2)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "createFile"),
+		[.labeledParameter("filePath", "_string1"),
+		 .labeledParameter("contents", "_string2")])
 
 	Utilities.deleteFolder(at: _string1)
-	_ = "Utilities.deleteFolder(path = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "deleteFolder"),
+		[.labeledParameter("path", "_string1")])
 
 	Utilities.deleteFile(at: _string1)
-	_ = "Utilities.deleteFile(path = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Utilities", "deleteFolder"),
+		[.labeledParameter("path", "_string1")])
 
     // Shell translations
     _ = Shell.runShellCommand(
         _string1, arguments: _stringArray1, fromFolder: _string2)
-    _ = "Shell.runShellCommand(_string1, arguments = _stringArray1, currentFolder = _string2)"
+	_ = GRYTemplate.call(
+		.dot("Shell", "runShellCommand"),
+		["_string1",
+		 .labeledParameter("arguments", "_stringArray1"),
+		 .labeledParameter("currentFolder", "_string2")])
 
     _ = Shell.runShellCommand(
         _string1, arguments: _stringArray1)
-    _ = "Shell.runShellCommand(_string1, arguments = _stringArray1)"
+	_ = GRYTemplate.call(
+		.dot("Shell", "runShellCommand"),
+		["_string1",
+		 .labeledParameter("arguments", "_stringArray1")])
 
     //
     _ = Shell.runShellCommand(_stringArray1, fromFolder: _string1)
-    _ = "Shell.runShellCommand(_stringArray1, currentFolder = _string1)"
+	_ = GRYTemplate.call(
+		.dot("Shell", "runShellCommand"),
+		["_stringArray1",
+		 .labeledParameter("currentFolder", "_string1")])
 
     _ = Shell.runShellCommand(_stringArray1)
-    _ = "Shell.runShellCommand(_stringArray1)"
+	_ = GRYTemplate.call(.dot("Shell", "runShellCommand"), ["_stringArray1"])
 
 	//
 	_ = OS.OSType.macOS
-	_ = "OS.OSType.MAC_OS"
+	_ = GRYTemplate.dot(.dot("OS", "OSType"), "MAC_OS")
 
 	_ = OS.OSType.linux
-	_ = "OS.OSType.LINUX"
+	_ = GRYTemplate.dot(.dot("OS", "OSType"), "LINUX")
 }
 
 public struct GryphonError: Error, CustomStringConvertible {

--- a/Test cases/standardLibrary.kt
+++ b/Test cases/standardLibrary.kt
@@ -263,12 +263,29 @@ fun main(args: Array<String>) {
 		// ...
 	}
 
-	listOf(1, 2, 3).map { a ->
-			if (true) {
-				return@map 1
-			}
-			else {
-				return@map 2
-			}
-		}
+	println(
+		listOf(1, 2, 3).map { a ->
+					if (a > 1) {
+						return@map 1
+					}
+					else {
+						return@map 2
+					}
+				})
+	println(
+		listOf(1, 2, 3).map { a ->
+					if (a > 1) {
+						return@map listOf(1, 2, 3).filter { b ->
+								if (b > 1) {
+									return@filter true
+								}
+								else {
+									return@filter false
+								}
+							}
+					}
+					else {
+						return@map listOf(2)
+					}
+				})
 }

--- a/Test cases/standardLibrary.kt
+++ b/Test cases/standardLibrary.kt
@@ -32,6 +32,10 @@ internal fun printTest(contents: PrintContents, testName: String) {
 	println("(${testName})")
 }
 
+internal open class A {
+	val string: String = ""
+}
+
 fun g(a: Int) {
 	printTest(a, "User template")
 }
@@ -250,4 +254,21 @@ fun main(args: Array<String>) {
 	printTest(Int.MIN_VALUE until 0, "Recursive matches")
 
 	g(a = 10)
+
+	val maybeA: A? = null
+	val a: A? = maybeA
+	val b: Char? = a?.string?.firstOrNull()
+
+	if (a != null && b != null) {
+		// ...
+	}
+
+	listOf(1, 2, 3).map { a ->
+			if (true) {
+				return@map 1
+			}
+			else {
+				return@map 2
+			}
+		}
 }

--- a/Test cases/standardLibrary.output
+++ b/Test cases/standardLibrary.output
@@ -145,3 +145,5 @@ true                                    (Dictionary isEmpty)
 1.0..3.0                                (Double ...)
 -2147483648..-1                         (Recursive matches)
 10                                      (User template)
+[2, 1, 1]
+[[2], [2, 3], [2, 3]]

--- a/Test cases/standardLibrary.swift
+++ b/Test cases/standardLibrary.swift
@@ -536,11 +536,28 @@ if let a = maybeA, let b = a.string.first {
 }
 
 // Adding `@map` labels in closures called by functions in templates
-[1, 2, 3].map { (a: Int) -> Int in
-	if true {
+print([1, 2, 3].map { (a: Int) -> Int in
+	if a > 1 {
 		return 1
 	}
 	else {
 		return 2
 	}
-}
+})
+
+// Adding labels for nested closures
+print([1, 2, 3].map { (a: Int) -> [Int] in
+	if a > 1 {
+		return [1, 2, 3].filter { (b: Int) -> Bool in
+			if b > 1 {
+				return true
+			}
+			else {
+				return false
+			}
+		}
+	}
+	else {
+		return [2]
+	}
+})


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Renames the structured templates in the templates library (to avoid clashes) and declares them as `internal` in the Gryphon Swift Library so they can be used by developers.
Also adds tests for some bugfixes brought by structured templates (like chained optionals and labeled returns) and add a bugfix for labeled returns in nested closures.

### Does this resolve an open issue?
No.
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).
