### PR TITLE
Fix lambda labels

### DIFF
--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -2662,7 +2662,9 @@ public class ReturnsInLambdasTranspilationPass: TranspilationPass {
 		if let declarationReferenceExpression =
 			functionExpression as? DeclarationReferenceExpression
 		{
-			return declarationReferenceExpression.identifier
+			let functionName = declarationReferenceExpression.identifier // `foo(arg:)`
+			let functionPrefix = String(functionName.prefix(while: { $0 != "(" }))
+			return functionPrefix
 		}
 		else if let dotExpression = functionExpression as? DotExpression {
 			return getLabelForFunction(dotExpression.rightExpression)

--- a/Test cases/closures.kt
+++ b/Test cases/closures.kt
@@ -143,4 +143,12 @@ fun main(args: Array<String>) {
 				else -> 1
 			}
 		}
+	foo { bla ->
+			if (true) {
+				return@foo 0
+			}
+			else {
+				return@foo 1
+			}
+		}
 }

--- a/Test cases/closures.swift
+++ b/Test cases/closures.swift
@@ -154,3 +154,13 @@ foo {
 	default: return 1
 	}
 }
+
+// Test labels in lambda returns
+foo { bla in
+	if true {
+		return 0
+	}
+	else {
+		return 1
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Closures that have labels referring to functions with named parameters would include the parameter names (e.g. `return@foo(a:)` instead of `return@foo`). This should fix that problem.

### Does this resolve an open issue?
Yeah, it resolves #66.
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [X] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [X] You ran the unit tests and Bootstrapping tests for your platform.
  - [X] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [X] You have added new tests that check your changes (if possible).
- [X] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

