### PR TITLE
Support single-expression functions

### DIFF
--- a/Test cases/functionCalls.kt
+++ b/Test cases/functionCalls.kt
@@ -29,6 +29,22 @@ internal fun definition4(): Int {
 	return 0
 }
 
+internal fun definition5(): Int = 5
+
+internal fun aaaaaaaaaaaaa(
+	bbbbbbbbbbbbbbbb: Int,
+	ccccccccccccc: Int,
+	ddddddddddddddddddddddddd: Int,
+	eeeeeeeeeee: Int)
+	: String
+	= "abc"
+
+internal fun d(): String = aaaaaaaaaaaaa(
+		bbbbbbbbbbbbbbbb = 0,
+		ccccccccccccc = 0,
+		ddddddddddddddddddddddddd = 0,
+		eeeeeeeeeee = 0)
+
 internal fun foo() {
 }
 

--- a/Test cases/functionCalls.swift
+++ b/Test cases/functionCalls.swift
@@ -42,6 +42,19 @@ func definition4() -> Int {
 	return 0
 }
 
+// Single-expression func
+func definition5() -> Int {
+	5
+}
+
+func aaaaaaaaaaaaa(bbbbbbbbbbbbbbbb: Int, ccccccccccccc: Int, ddddddddddddddddddddddddd: Int, eeeeeeeeeee: Int) -> String {
+	"abc"
+}
+
+func d() -> String {
+	aaaaaaaaaaaaa(bbbbbbbbbbbbbbbb: 0, ccccccccccccc: 0, ddddddddddddddddddddddddd: 0, eeeeeeeeeee: 0)
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function calls without return types
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?

With this change, the following translation is done:

```swift
func example() -> String {
  "Hello, World"
}
```

```kotlin
fun example(): String = "Hello, World"
```

The translation is only done when the function has a return type that is
equal to the value of the expression. So there are the two cases:

```swift
func example2() -> String {
  example()
}

func example3() {
  example()
}
```

```kotlin
fun example2(): String = example()

fun example3() {
  example()
}
```

Due to changes in Swift 5.1, functions with a single expression and a return type
can omit the 'return' keyword. 

>  A closure that consists of only a single expression is understood to return the value of that expression.

Kotlin calls these "single-expression functions". See the documentation for more
info: https://kotlinlang.org/docs/reference/functions.html#single-expression-functions.

### Does this resolve an open issue?
Yeah, it resolves #72.
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

