### PR TITLE
Description properties in types that are known not to conform to CustomStringConvertible shouldn't be turned into `toString()`

### DIFF
--- a/Sources/GryphonLib/AuxiliaryFileContents.swift
+++ b/Sources/GryphonLib/AuxiliaryFileContents.swift
@@ -1261,6 +1261,11 @@ private struct _Comparable: Comparable {
 // Replacement for Optional
 private struct _Optional { }
 
+// Replacement for CustomStringConvertible
+private struct _CustomStringConvertible: CustomStringConvertible {
+	var description: String = ""
+}
+
 // Replacement for Any
 private struct _Any: CustomStringConvertible, LosslessStringConvertible {
 	init() { }
@@ -1297,6 +1302,7 @@ private func gryphonTemplates() {
 	let _range: Range<String.Index> = _string.startIndex..<_string.endIndex
 	let _any: Any = "abc"
 	let _anyType: _Any = _Any()
+	let _customStringConvertible = _CustomStringConvertible()
 	let _optional: _Optional? = _Optional()
 	let _float: Float = 0
 	let _double: Double = 0
@@ -1359,8 +1365,8 @@ private func gryphonTemplates() {
 	_ = String(_anyType)
 	_ = _GRYTemplate.call(.dot("_anyType", "toString"), [])
 
-	_ = _anyType.description
-	_ = _GRYTemplate.call(.dot("_anyType", "toString"), [])
+	_ = _customStringConvertible.description
+	_ = _GRYTemplate.call(.dot("_customStringConvertible", "toString"), [])
 
 	_ = _string.isEmpty
 	_ = _GRYTemplate.call(.dot("_string", "isEmpty"), [])

--- a/Sources/GryphonLib/TranspilationContext.swift
+++ b/Sources/GryphonLib/TranspilationContext.swift
@@ -126,6 +126,19 @@ public class TranspilationContext {
 		protocols.append(protocolName)
 	}
 
+	///
+	/// This variable is used to store the inheritances (superclasses and protocols) of each type.
+	/// Keys correspond to the type, values correspond to its inheritances.
+	///
+	private(set) var inheritances: MutableMap<String, List<String>> = [:]
+
+	public func addInheritances(
+		forType typeName: String,
+		inheritances typeInheritances: List<String>)
+	{
+		inheritances[typeName] = typeInheritances
+	}
+
 	// MARK: - Function translations
 
 	/// Stores information on how a Swift function should be translated into Kotlin, including what

--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -933,10 +933,64 @@ public class DescriptionAsToStringTranspilationPass: TranspilationPass {
 		_ variableDeclaration: VariableDeclaration)
 		-> List<Statement>
 	{
+		// Get the type that declares this property, if any
+		var maybeTypeParent: String?
+		for parent in parents {
+			if case let .statementNode(value: parentStatement) = parent {
+				if let classDeclaration = parentStatement as? ClassDeclaration {
+					maybeTypeParent = classDeclaration.className
+				}
+				else if let structDeclaration = parentStatement as? StructDeclaration {
+					maybeTypeParent = structDeclaration.structName
+				}
+				else if let enumDeclaration = parentStatement as? EnumDeclaration {
+					maybeTypeParent = enumDeclaration.enumName
+				}
+			}
+		}
+
+		if let typeParent = maybeTypeParent {
+			if let inheritances = context.inheritances[typeParent] {
+				// If the description variable isn't satisfying a CustomStringConvertible
+				// requirement, do nothing
+				if !inheritances.contains("CustomStringConvertible") {
+					return super.replaceVariableDeclaration(variableDeclaration)
+				}
+			}
+			else {
+				// If we found the parent type, its inheritances should have been recorded earlier.
+				// Something went wrong.
+				do {
+					try Compiler.handleError(
+						message: "Unable to check inheritances for \(typeParent)",
+						sourceFile: ast.sourceFile,
+						sourceFileRange: variableDeclaration.range)
+				}
+				catch { }
+				return [ErrorStatement(range: variableDeclaration.range)]
+			}
+		}
+		else {
+			// Local variable, do nothing
+			return super.replaceVariableDeclaration(variableDeclaration)
+		}
+
 		if variableDeclaration.identifier == "description",
-			variableDeclaration.typeName == "String",
-			let getter = variableDeclaration.getter
+			variableDeclaration.typeName == "String"
 		{
+			let statements: MutableList<Statement>
+			if let getterStatements = variableDeclaration.getter?.statements {
+				statements = getterStatements
+			}
+			else if let expression = variableDeclaration.expression {
+				statements = [ExpressionStatement(
+					range: expression.range,
+					expression: expression)]
+			}
+			else {
+				return super.replaceVariableDeclaration(variableDeclaration)
+			}
+
 			let newAnnotations = variableDeclaration.annotations
 			if !newAnnotations.contains("override") {
 				newAnnotations.append("override")
@@ -956,7 +1010,7 @@ public class DescriptionAsToStringTranspilationPass: TranspilationPass {
 				isPure: false,
 				isJustProtocolInterface: false,
 				extendsType: variableDeclaration.extendsType,
-				statements: getter.statements,
+				statements: statements,
 				access: "public",
 				annotations: newAnnotations), ]
 		}
@@ -2750,7 +2804,7 @@ public class TuplesToPairsTranspilationPass: TranspilationPass {
 	{
 		// Ensure it's a pair
 		guard tupleExpression.pairs.count == 2 else {
-			return super.replaceTupleExpression(tupleExpression) 
+			return super.replaceTupleExpression(tupleExpression)
 		}
 
 		// Ignore tuples in call expressions and for statements
@@ -3506,6 +3560,45 @@ public class RecordInitializersTranspilationPass: TranspilationPass {
 				parameters: initializerDeclaration.parameters.map { $0.label }.toMutableList()))
 
 		return super.processInitializerDeclaration(initializerDeclaration)
+	}
+}
+
+/// Records the superclass and protocol inheritances of any enum, struct or class declaration.
+/// Inheritances are copied to avoid them changing accidentally later.
+///
+/// TODO: This can cause issues when two nested classes have the same name (e.g. `A.B` and `C.B`).
+public class RecordInheritancesTranspilationPass: TranspilationPass {
+	// gryphon insert: constructor(ast: GryphonAST, context: TranspilationContext):
+	// gryphon insert:     super(ast, context) { }
+
+	override func replaceEnumDeclaration( // gryphon annotation: override
+		_ enumDeclaration: EnumDeclaration)
+		-> List<Statement>
+	{
+		self.context.addInheritances(
+			forType: enumDeclaration.enumName,
+			inheritances: enumDeclaration.inherits.toList())
+		return super.replaceEnumDeclaration(enumDeclaration)
+	}
+
+	override func replaceStructDeclaration( // gryphon annotation: override
+		_ structDeclaration: StructDeclaration)
+		-> List<Statement>
+	{
+		self.context.addInheritances(
+			forType: structDeclaration.structName,
+			inheritances: structDeclaration.inherits.toList())
+		return super.replaceStructDeclaration(structDeclaration)
+	}
+
+	override func replaceClassDeclaration( // gryphon annotation: override
+		_ classDeclaration: ClassDeclaration)
+		-> List<Statement>
+	{
+		self.context.addInheritances(
+			forType: classDeclaration.className,
+			inheritances: classDeclaration.inherits.toList())
+		return super.replaceClassDeclaration(classDeclaration)
 	}
 }
 
@@ -4623,17 +4716,18 @@ public extension TranspilationPass {
 		// Remove declarations that shouldn't even be considered in the passes
 		ast = RemoveImplicitDeclarationsTranspilationPass(ast: ast, context: context).run()
 
+		// Record information on enum and function translations
+		ast = RecordTemplatesTranspilationPass(ast: ast, context: context).run()
+		ast = RecordProtocolsTranspilationPass(ast: ast, context: context).run()
+		ast = RecordFunctionsTranspilationPass(ast: ast, context: context).run()
+		ast = RecordInitializersTranspilationPass(ast: ast, context: context).run()
+		ast = RecordInheritancesTranspilationPass(ast: ast, context: context).run()
+
 		// RecordEnums needs to be after CleanInheritance: it needs Swift-only inheritances removed
 		// in order to know if the enum inherits from a class or not, and therefore is a sealed
 		// class or an enum class.
 		ast = CleanInheritancesTranspilationPass(ast: ast, context: context).run()
-
-		// Record information on enum and function translations
-		ast = RecordTemplatesTranspilationPass(ast: ast, context: context).run()
 		ast = RecordEnumsTranspilationPass(ast: ast, context: context).run()
-		ast = RecordProtocolsTranspilationPass(ast: ast, context: context).run()
-		ast = RecordFunctionsTranspilationPass(ast: ast, context: context).run()
-		ast = RecordInitializersTranspilationPass(ast: ast, context: context).run()
 
 		return ast
 	}

--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -983,9 +983,12 @@ public class DescriptionAsToStringTranspilationPass: TranspilationPass {
 				statements = getterStatements
 			}
 			else if let expression = variableDeclaration.expression {
-				statements = [ExpressionStatement(
+				// TODO: this can be a single expression once single-expression functions are
+				// supported
+				statements = [ReturnStatement(
 					range: expression.range,
-					expression: expression)]
+					expression: expression,
+					label: nil)]
 			}
 			else {
 				return super.replaceVariableDeclaration(variableDeclaration)

--- a/Test cases/misc.kt
+++ b/Test cases/misc.kt
@@ -45,6 +45,18 @@ internal open class Subclass: Base {
 	constructor(): super() { }
 }
 
+internal open class E {
+	override open fun toString(): String {
+		return "abc"
+	}
+}
+
+internal open class F {
+	override open fun toString(): String {
+		return "abc"
+	}
+}
+
 fun main(args: Array<String>) {
 	var i: Int = 1
 

--- a/Test cases/misc.swift
+++ b/Test cases/misc.swift
@@ -107,3 +107,15 @@ let bla: Array<Int>.ArrayLiteralElement = 1
 
 // Test types with parentheses
 var foo: (() -> ())? = nil
+
+// Description as toString() for properties with getters
+class E: CustomStringConvertible {
+	var description: String {
+		return "abc"
+	}
+}
+
+// Description as toString() for properties without getters
+class F: CustomStringConvertible {
+	var description: String = "abc"
+}

--- a/Test cases/standardLibrary.kt
+++ b/Test cases/standardLibrary.kt
@@ -36,8 +36,26 @@ internal open class A {
 	val string: String = ""
 }
 
+internal open class B {
+	open var description: String = ""
+}
+
+internal open class C {
+	override open fun toString(): String {
+		""
+	}
+}
+
 fun g(a: Int) {
 	printTest(a, "User template")
+}
+
+internal open class D {
+	open class E {
+		override open fun toString(): String {
+			""
+		}
+	}
 }
 
 fun main(args: Array<String>) {
@@ -288,4 +306,8 @@ fun main(args: Array<String>) {
 						return@map listOf(2)
 					}
 				})
+
+	val description1: String = B().description
+	val description2: String = C().toString()
+	val description: String = ""
 }

--- a/Test cases/standardLibrary.kt
+++ b/Test cases/standardLibrary.kt
@@ -42,7 +42,7 @@ internal open class B {
 
 internal open class C {
 	override open fun toString(): String {
-		""
+		return ""
 	}
 }
 
@@ -53,7 +53,7 @@ fun g(a: Int) {
 internal open class D {
 	open class E {
 		override open fun toString(): String {
-			""
+			return ""
 		}
 	}
 }

--- a/Test cases/standardLibrary.swift
+++ b/Test cases/standardLibrary.swift
@@ -512,9 +512,17 @@ func gryphonTemplates() {
 }
 
 //////////////////////////////////////////////////////////
-// Auxiliary declarations
+// Auxiliary declarations for the following tests
 class A {
 	let string: String = ""
+}
+
+class B {
+	var description: String = ""
+}
+
+class C: CustomStringConvertible {
+	var description: String = ""
 }
 
 func f(of a: Int) { // gryphon ignore
@@ -561,3 +569,22 @@ print([1, 2, 3].map { (a: Int) -> [Int] in
 		return [2]
 	}
 })
+
+//////////////////////////////////////////////////////////
+// Inheritance checking
+
+// B doesn't conform to CustomStringConvertible, so this is `B().description`
+let description1 = B().description
+
+// C conforms to CustomStringConvertible, so this is `C().toString()`
+let description2 = C().description
+
+// Local variables don't get translated
+let description: String = ""
+
+// Nested classes get translated
+class D {
+	class E: CustomStringConvertible {
+		var description: String = ""
+	}
+}


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Avoid turning declarations of (and references to) `description` properties into `toString()` when we know the type doesn't conform to CustomStringConvertible.

### Does this resolve an open issue?
It might resolve #71 .
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [x] You have added new tests that check your changes (if possible).
- [X] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

