### PR TITLE
Feature: support `let _` statements

### DIFF
--- a/Sources/GryphonLib/SwiftTranslator.swift
+++ b/Sources/GryphonLib/SwiftTranslator.swift
@@ -315,8 +315,18 @@ public class SwiftTranslator {
 		case "Defer Statement":
 			result = [try translateDeferStatement(subtree)]
 		case "Pattern Binding Declaration":
-			try processPatternBindingDeclaration(subtree)
-			result = []
+			// If it's a `let _ = <expression>`
+			if subtree.subtrees.count == 2,
+				subtree.subtrees[0].name == "Pattern Any"
+			{
+				result = try [ExpressionStatement(
+					range: getRangeRecursively(ofNode: subtree),
+					expression: translateExpression(subtree.subtrees[1]))]
+			}
+			else {
+				try processPatternBindingDeclaration(subtree)
+				result = []
+			}
 		case "Return Statement":
 			result = [try translateReturnStatement(subtree)]
 		case "Break Statement":

--- a/Test cases/misc.kt
+++ b/Test cases/misc.kt
@@ -92,4 +92,6 @@ fun main(args: Array<String>) {
 	val arrayIndex: Int? = array.indexOf(1)
 	val bla: Int = 1
 	var foo: (() -> Unit)? = null
+
+	"abc"
 }

--- a/Test cases/misc.swift
+++ b/Test cases/misc.swift
@@ -119,3 +119,6 @@ class E: CustomStringConvertible {
 class F: CustomStringConvertible {
 	var description: String = "abc"
 }
+
+// Anonymous pattern binding
+let _ = "abc"


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Adds support for `let _ = <expression>` statements.

### Does this resolve an open issue?
Yeah, it resolves #69.
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

