### PR TITLE
Feature: raise warnings for initializers in structs

### DIFF
--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -3760,6 +3760,44 @@ public class RaiseMutableValueTypesWarningsTranspilationPass: TranspilationPass 
 	}
 }
 
+/// Struct initializers aren't yet supported; this raises warnings when they're detected.
+public class RaiseStructInitializerWarningsTranspilationPass: TranspilationPass {
+	// gryphon insert: constructor(ast: GryphonAST, context: TranspilationContext):
+	// gryphon insert:     super(ast, context) { }
+
+	override func processInitializerDeclaration(
+		_ initializerDeclaration: InitializerDeclaration)
+		-> InitializerDeclaration?
+	{
+		// Get the type that declares this property, if any
+		var isStructInitializer: Bool = false
+		for parent in parents {
+			if case let .statementNode(value: parentStatement) = parent {
+				if parentStatement is ClassDeclaration || parentStatement is EnumDeclaration {
+					isStructInitializer = false
+				}
+				else if parentStatement is StructDeclaration {
+					isStructInitializer = true
+				}
+			}
+		}
+
+		if isStructInitializer {
+			let message = "Secondary initializers in structs are not yet supported." +
+				" Consider using default values for the struct's properties instead."
+			Compiler.handleWarning(
+				message: message,
+				ast: initializerDeclaration,
+				sourceFile: ast.sourceFile,
+				sourceFileRange: initializerDeclaration.range)
+			return nil
+		}
+		else {
+			return super.processInitializerDeclaration(initializerDeclaration)
+		}
+	}
+}
+
 /// `MutableList`s, `List`s, `MutableMap`s, and `Map`s are prefered to
 /// using `Arrays` and `Dictionaries` for guaranteeing correctness. This pass raises warnings when
 /// it finds uses of the native data structures, which should help avoid these bugs.
@@ -3773,7 +3811,7 @@ public class RaiseNativeDataStructureWarningsTranspilationPass: TranspilationPas
 	{
 		if let type = expression.swiftType, type.hasPrefix("[") {
 			let message = "Native type \(type) can lead to different behavior in Kotlin. Prefer " +
-			"MutableList, List, MutableMap or Map instead."
+				"MutableList, List, MutableMap or Map instead."
 			Compiler.handleWarning(
 				message: message,
 				ast: expression,
@@ -4816,6 +4854,7 @@ public extension TranspilationPass {
 		ast = RaiseStandardLibraryWarningsTranspilationPass(ast: ast, context: context).run()
 		ast = RaiseDoubleOptionalWarningsTranspilationPass(ast: ast, context: context).run()
 		ast = RaiseMutableValueTypesWarningsTranspilationPass(ast: ast, context: context).run()
+		ast = RaiseStructInitializerWarningsTranspilationPass(ast: ast, context: context).run()
 		ast = RaiseNativeDataStructureWarningsTranspilationPass(ast: ast, context: context).run()
 
 		return ast

--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -3765,7 +3765,7 @@ public class RaiseStructInitializerWarningsTranspilationPass: TranspilationPass 
 	// gryphon insert: constructor(ast: GryphonAST, context: TranspilationContext):
 	// gryphon insert:     super(ast, context) { }
 
-	override func processInitializerDeclaration(
+	override func processInitializerDeclaration( // gryphon annotation: override
 		_ initializerDeclaration: InitializerDeclaration)
 		-> InitializerDeclaration?
 	{

--- a/Test cases/warnings.swift
+++ b/Test cases/warnings.swift
@@ -86,5 +86,20 @@ class B: A {
 	}
 }
 
+// Test warnings on struct initializers
+struct C {
+	let c = 0
+
+	init() { } // warning here
+}
+
+struct D {
+	let d = 0
+
+	class E {
+		init() { } // no warning here
+	}
+}
+
 // Test muting warnings
 let noWarnings: [Int] = [] // gryphon mute

--- a/Tests/GryphonLibTests/IntegrationTest.swift
+++ b/Tests/GryphonLibTests/IntegrationTest.swift
@@ -171,8 +171,8 @@ class IntegrationTest: XCTestCase {
 
 				// Make sure the comment for muting warnings is working
 				XCTAssert(
-					Compiler.numberOfWarnings == 11,
-					"Expected 11 warnings, found \(Compiler.numberOfErrors):\n" +
+					Compiler.numberOfWarnings == 12,
+					"Expected 11 warnings, found \(Compiler.numberOfWarnings):\n" +
 						Compiler.issues.filter { !$0.isError }.map { $0.fullMessage }
 							.joined(separator: "\n"))
 
@@ -224,6 +224,14 @@ class IntegrationTest: XCTestCase {
 				XCTAssertEqual(
 					warnings.count, 2,
 					"Expected 2 warnings containing \"superclass's initializer\", " +
+						"found \(warnings.count) (printed below, if any).\n" +
+						warnings.map { $0.fullMessage }.joined(separator: "\n"))
+
+				warnings =
+					Compiler.issues.filter { $0.fullMessage.contains("initializers in structs") }
+				XCTAssertEqual(
+					warnings.count, 1,
+					"Expected 1 warnings containing \"initializers in structs\", " +
 						"found \(warnings.count) (printed below, if any).\n" +
 						warnings.map { $0.fullMessage }.joined(separator: "\n"))
 			}


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
This raises warnings when initializers are declared in structs, which isn't supported yet.

### Does this resolve an open issue?
No, but it's related to #70 .
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

