### PR TITLE
Description single expression

### DIFF
--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -983,12 +983,9 @@ public class DescriptionAsToStringTranspilationPass: TranspilationPass {
 				statements = getterStatements
 			}
 			else if let expression = variableDeclaration.expression {
-				// TODO: this can be a single expression once single-expression functions are
-				// supported
-				statements = [ReturnStatement(
+				statements = [ExpressionStatement(
 					range: expression.range,
-					expression: expression,
-					label: nil)]
+					expression: expression)]
 			}
 			else {
 				return super.replaceVariableDeclaration(variableDeclaration)

--- a/Test cases/misc.kt
+++ b/Test cases/misc.kt
@@ -52,9 +52,7 @@ internal open class E {
 }
 
 internal open class F {
-	override open fun toString(): String {
-		return "abc"
-	}
+	override open fun toString(): String = "abc"
 }
 
 fun main(args: Array<String>) {

--- a/Test cases/standardLibrary.kt
+++ b/Test cases/standardLibrary.kt
@@ -41,9 +41,7 @@ internal open class B {
 }
 
 internal open class C {
-	override open fun toString(): String {
-		return ""
-	}
+	override open fun toString(): String = ""
 }
 
 fun g(a: Int) {
@@ -52,9 +50,7 @@ fun g(a: Int) {
 
 internal open class D {
 	open class E {
-		override open fun toString(): String {
-			return ""
-		}
+		override open fun toString(): String = ""
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Description properties declared as assignments (e.g. `var description = "abc"`) can be turned into single-expression functions, omitting the `return` keyword.

### Does this resolve an open issue?
No.
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [x] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [x] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).
