### PR TITLE
Fixing protocol inheritance

### DIFF
--- a/Sources/GryphonLib/TranspilationPass.swift
+++ b/Sources/GryphonLib/TranspilationPass.swift
@@ -2311,6 +2311,22 @@ public class CleanInheritancesTranspilationPass: TranspilationPass {
 				.toMutableList(),
 			members: structDeclaration.members))
 	}
+    
+    override func replaceProtocolDeclaration(
+        _ protocolDeclaration: ProtocolDeclaration)
+        -> List<Statement>
+    {
+        return super.replaceProtocolDeclaration(ProtocolDeclaration(
+            range: protocolDeclaration.range,
+            protocolName: protocolDeclaration.protocolName,
+            access: protocolDeclaration.access,
+            annotations: protocolDeclaration.annotations,
+            members: protocolDeclaration.members,
+            inherits: protocolDeclaration.inherits
+                .filter { !TranspilationPass.isASwiftProtocol($0) }
+                .toMutableList()
+            ))
+    }
 
 	override func replaceClassDeclaration(
 		_ classDeclaration: ClassDeclaration)


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Implementing a checker to see if the protocol isn't inheriting a swift keyword/type alias.

### Does this resolve an open issue?
No

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [ ] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
- [ ] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

