### PR TITLE
Support -UseModernBuildSystem for xcodebuild

### DIFF
--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -950,16 +950,25 @@ public class Driver {
 					"Unable to find the Swift compilation command in the Xcode project.")
 			}
 		}
-		Compiler.log("ℹ️  SwiftCompiler step output: \(compileSwiftStep)\n")
+		// Compiler.log("ℹ️  SwiftCompiler step output: \(compileSwiftStep)\n\n")
 
 		Compiler.log("ℹ️  Adapting Swift compilation command for dumping ASTs...")
 
 		var sourceKitFileContents = ""
 
-		let commandComponents = compileSwiftStep.splitUsingUnescapedSpaces()
+		let splittedCommandComponents = compileSwiftStep.splitUsingUnescapedSpaces()
+		
+		var swiftComponentIndex = 0
+		for i in 0..<splittedCommandComponents.count {
+			if splittedCommandComponents[i].hasSuffix("swiftc") {
+				swiftComponentIndex = i
+				break
+			}
+		}
+		let commandComponents = splittedCommandComponents.dropFirst(swiftComponentIndex + 1)
 		
 		for i in 0..<commandComponents.count {
-			Compiler.log("ℹ️  Swift Compiler argument \(i):\n \(commandComponents[i])\n")
+			// Compiler.log("ℹ️  Swift Compiler argument \(i):\n \(commandComponents[i])\n")
 		}
 
 		let filteredArguments = commandComponents.filter { (argument: String) -> Bool in

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -224,6 +224,7 @@ public class Driver {
 			try makeGryphonTargets(
 				forXcodeProject: xcodeProject,
 				forTarget: target,
+				useModernBuildSystem: enableModernBuildSystem,
 				configFiles: configFiles)
 
 			Compiler.logEnd("✅  Done adding Gryphon targets.")
@@ -997,6 +998,7 @@ public class Driver {
 	static func makeGryphonTargets(
 		forXcodeProject xcodeProjectPath: String,
 		forTarget target: String?,
+		useModernBuildSystem: Bool,
 		configFiles: List<String>)
 		throws
 	{
@@ -1007,6 +1009,8 @@ public class Driver {
 			"\(SupportingFile.makeGryphonTargets.absolutePath)",
 			"\(xcodeProjectPath)", ]
 
+		let modernBuildSystemStringValue = useModernBuildSystem ? "YES": "NO"
+		arguments.append("--UseModernBuildSystem=\(modernBuildSystemStringValue)")
 		// Any other arguments will be appended to the target's script
 		if let userTarget = target {
 			arguments.append("--target=\"\(userTarget)\"")

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -950,15 +950,17 @@ public class Driver {
 					"Unable to find the Swift compilation command in the Xcode project.")
 			}
 		}
+		Compiler.log("ℹ️  SwiftCompiler step output: \(compileSwiftStep)\n")
 
 		Compiler.log("ℹ️  Adapting Swift compilation command for dumping ASTs...")
-		let commands = compileSwiftStep.split(withStringSeparator: "\n")
 
 		var sourceKitFileContents = ""
 
-		// Fix the call to the Swift compiler
-		let compilationCommand = commands.last!
-		let commandComponents = compilationCommand.splitUsingUnescapedSpaces()
+		let commandComponents = compileSwiftStep.splitUsingUnescapedSpaces()
+		
+		for i in 0..<commandComponents.count {
+			Compiler.log("ℹ️  Swift Compiler argument \(i):\n \(commandComponents[i])\n")
+		}
 
 		let filteredArguments = commandComponents.filter { (argument: String) -> Bool in
 			argument != "-incremental" &&

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -950,7 +950,6 @@ public class Driver {
 					"Unable to find the Swift compilation command in the Xcode project.")
 			}
 		}
-		// Compiler.log("ℹ️  SwiftCompiler step output: \(compileSwiftStep)\n\n")
 
 		Compiler.log("ℹ️  Adapting Swift compilation command for dumping ASTs...")
 
@@ -965,11 +964,7 @@ public class Driver {
 				break
 			}
 		}
-		let commandComponents = splittedCommandComponents.dropFirst(swiftComponentIndex + 1)
-		
-		for i in 0..<commandComponents.count {
-			// Compiler.log("ℹ️  Swift Compiler argument \(i):\n \(commandComponents[i])\n")
-		}
+		let commandComponents = splittedCommandComponents.dropFirst(swiftComponentIndex)
 
 		let filteredArguments = commandComponents.filter { (argument: String) -> Bool in
 			argument != "-incremental" &&

--- a/Sources/GryphonLib/Driver.swift
+++ b/Sources/GryphonLib/Driver.swift
@@ -917,13 +917,17 @@ public class Driver {
 
 			let separator = "=== BUILD TARGET "
 			let components = output.split(withStringSeparator: separator)
-			guard let selectedComponent = components.first(where: { $0.hasPrefix(userTarget) })
-				else
-			{
-				throw GryphonError(errorMessage: "Failed to find build instructions for target " +
-					"\(userTarget) in the xcodebuild output.")
+			if components.count > 1 {
+				guard let selectedComponent = components.first(where: { $0.hasPrefix(userTarget) })
+					else
+				{
+					throw GryphonError(errorMessage: "Failed to find build instructions for target " +
+						"\(userTarget) in the xcodebuild output.")
+				}
+				targetContents = selectedComponent
+			} else {
+				targetContents = output
 			}
-			targetContents = selectedComponent
 		}
 		else {
 			targetContents = output

--- a/Sources/GryphonLib/SwiftSyntaxDecoder.swift
+++ b/Sources/GryphonLib/SwiftSyntaxDecoder.swift
@@ -451,7 +451,7 @@ public class SwiftSyntaxDecoder: SyntaxVisitor {
 						"⚠️ Something went wrong, attempting to update iOS compilation files")
 					try Driver.createIOSCompilationFiles(
 						forXcodeProject: xcodeProjectPath,
-                        useNewBuildSystem: "NO",
+						useModernBuildSystem: context.useModernBuildSystem,
 						forTarget: context.target)
 					let (sdkPath, otherSwiftArguments) =
 						try Driver.readCompilationArgumentsFromFile()

--- a/Sources/GryphonLib/SwiftSyntaxDecoder.swift
+++ b/Sources/GryphonLib/SwiftSyntaxDecoder.swift
@@ -451,6 +451,7 @@ public class SwiftSyntaxDecoder: SyntaxVisitor {
 						"⚠️ Something went wrong, attempting to update iOS compilation files")
 					try Driver.createIOSCompilationFiles(
 						forXcodeProject: xcodeProjectPath,
+                        useNewBuildSystem: false,
 						forTarget: context.target)
 					let (sdkPath, otherSwiftArguments) =
 						try Driver.readCompilationArgumentsFromFile()

--- a/Sources/GryphonLib/SwiftSyntaxDecoder.swift
+++ b/Sources/GryphonLib/SwiftSyntaxDecoder.swift
@@ -451,7 +451,7 @@ public class SwiftSyntaxDecoder: SyntaxVisitor {
 						"⚠️ Something went wrong, attempting to update iOS compilation files")
 					try Driver.createIOSCompilationFiles(
 						forXcodeProject: xcodeProjectPath,
-                        useNewBuildSystem: false,
+                        useNewBuildSystem: "NO",
 						forTarget: context.target)
 					let (sdkPath, otherSwiftArguments) =
 						try Driver.readCompilationArgumentsFromFile()

--- a/Sources/GryphonLib/TranspilationContext.swift
+++ b/Sources/GryphonLib/TranspilationContext.swift
@@ -24,6 +24,7 @@ public class TranspilationContext {
 	let xcodeProjectPath: String?
 	let pathConfigurations: Map< String, String>
 	let target: String?
+	let useModernBuildSystem: Bool
 	/// Absolute paths to any files included in the compilation, as well as any other `swiftc`
 	/// arguments (except for the SDK path, which should be set in `absolutePathToSDK`).
 	/// May be updated if we try to re-init an Xcode project to look for new Swift files.
@@ -72,6 +73,7 @@ public class TranspilationContext {
 		self.target = nil
 		self.swiftCompilationArguments = [SupportingFile.gryphonTemplatesLibrary.absolutePath]
 		self.absolutePathToSDK = nil
+		self.useModernBuildSystem = false
 	}
 
 	public init(
@@ -80,6 +82,7 @@ public class TranspilationContext {
 		xcodeProjectPath: String?,
 		pathConfigurations: Map<String, String>,
 		target: String?,
+		useModernBuildSystem: Bool,
 		swiftCompilationArguments: List<String>,
 		absolutePathToSDK: String?)
 		throws
@@ -89,6 +92,7 @@ public class TranspilationContext {
 		self.xcodeProjectPath = xcodeProjectPath
 		self.pathConfigurations = pathConfigurations
 		self.target = target
+		self.useModernBuildSystem = useModernBuildSystem
 		self.templates = try TranspilationContext
 			.getBaseContext()
 			.templates


### PR DESCRIPTION
This is needed to support projects which uses SwiftPackageManager frameworks.

<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
Replace this with a description of what you changed and why. Provide some links to existing discussions if there are any.

### Does this resolve an open issue?
Yeah, it resolves #123.
<!-- (Forgot your issue's number? look it up [here](https://github.com/vinivendra/Gryphon/issues)). -->

### Checklist for submitting a pull request:

- [ ] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [ ] You ran the unit tests and Bootstrapping tests for your platform.
  - [ ] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [ ] You have added new tests that check your changes (if possible).
- [ ] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).


Example of swift compiler step from `xcodebuild` command, it wasn't able to parse it without changes from this PR:
```
CompileSwiftSources normal arm64 com.apple.xcode.tools.swift.compiler (in target 'FrameworkNameKit' from project 'AppName')
    cd /Users/kyzmitch/prj/LegacyAppName/AppName
    export DEVELOPER_DIR\=/Applications/Xcode-13.2.1.app/Contents/Developer
    export SDKROOT\=/Applications/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.2.sdk
    /Applications/Xcode-13.2.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc -incremental -module-name FrameworkNameKit -O -whole-module-optimization -enforce-exclusivity\=checked @/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/Objects-normal/arm64/FrameworkNameKit.SwiftFileList -sdk /Applications/Xcode-13.2.1.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS15.2.sdk -target arm64-apple-ios13.0 -g -Xfrontend -serialize-debugging-options -embed-bitcode-marker -swift-version 5 -I /Users/kyzmitch/prj/LegacyAppName/AppName/build/Release-iphoneos -F /Users/kyzmitch/prj/LegacyAppName/AppName/build/Release-iphoneos -c -num-threads 8 -output-file-map /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/Objects-normal/arm64/FrameworkNameKit-OutputFileMap.json -parseable-output -serialize-diagnostics -emit-dependencies -emit-module -emit-module-path /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/Objects-normal/arm64/FrameworkNameKit.swiftmodule -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/swift-overrides.hmap -Xcc -iquote -Xcc /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/FrameworkNameKit-generated-files.hmap -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/FrameworkNameKit-own-target-headers.hmap -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/FrameworkNameKit-all-non-framework-target-headers.hmap -Xcc -ivfsoverlay -Xcc /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/all-product-headers.yaml -Xcc -iquote -Xcc /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/FrameworkNameKit-project-headers.hmap -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/Release-iphoneos/include -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/DerivedSources-normal/arm64 -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/DerivedSources/arm64 -Xcc -I/Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/DerivedSources -emit-objc-header -emit-objc-header-path /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/Objects-normal/arm64/FrameworkNameKit-Swift.h -import-underlying-module -Xcc -ivfsoverlay -Xcc /Users/kyzmitch/prj/LegacyAppName/AppName/build/AppName.build/Release-iphoneos/FrameworkNameKit.build/unextended-module-overlay.yaml -working-directory /Users/kyzmitch/prj/LegacyAppName/AppName
remark: Incremental compilation has been disabled: it is not compatible with whole module optimization
```