### PR TITLE
Swift 5.7 compability for the GryphonSwiftLibrary

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.5
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 //
@@ -25,76 +25,77 @@ import PackageDescription
 // To use a beta version of SwiftSyntax:
 //
 //let swiftSyntaxPackage = Package.Dependency.package(
-//	url: "https://github.com/apple/swift-syntax.git",
-//	.revision("release/5.6")) // <- git branch name
+//    url: "https://github.com/apple/swift-syntax.git",
+//    .revision("release/5.6")) // <- git branch name
 
 // Which SwiftSyntax version to use
 #if swift(>=5.6)
 let swiftSyntaxPackage = Package.Dependency.package(
-	name: "SwiftSyntax",
-	url: "https://github.com/apple/swift-syntax.git",
-	.exact("0.50600.1"))
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git",
+    .exact("0.50600.1"))
 #elseif swift(>=5.5)
 let swiftSyntaxPackage = Package.Dependency.package(
-	name: "SwiftSyntax",
-	url: "https://github.com/apple/swift-syntax.git",
-	.exact("0.50500.0"))
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git",
+    .exact("0.50500.0"))
 #elseif swift(>=5.4)
 let swiftSyntaxPackage = Package.Dependency.package(
-	name: "SwiftSyntax",
-	url: "https://github.com/apple/swift-syntax.git",
-	.exact("0.50400.0"))
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git",
+    .exact("0.50400.0"))
 #elseif swift(>=5.3)
 let swiftSyntaxPackage = Package.Dependency.package(
-	name: "SwiftSyntax",
-	url: "https://github.com/apple/swift-syntax.git",
-	.exact("0.50300.0"))
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git",
+    .exact("0.50300.0"))
 #else
 let swiftSyntaxPackage = Package.Dependency.package(
-	name: "SwiftSyntax",
-	url: "https://github.com/apple/swift-syntax.git",
-	.exact("0.50200.0"))
+    name: "SwiftSyntax",
+    url: "https://github.com/apple/swift-syntax.git",
+    .exact("0.50200.0"))
 #endif
 
 // Which modules to import from SwiftSyntax (and SourceKitten)
 #if swift(>=5.6)
 let gryphonLibDependencies: [Target.Dependency] = [
-	.product(name: "SwiftSyntax", package: "SwiftSyntax"),
-	.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
-	.product(name: "SourceKittenFramework", package: "SourceKitten")
+    .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+    .product(name: "SwiftSyntaxParser", package: "SwiftSyntax"),
+    .product(name: "SourceKittenFramework", package: "SourceKitten")
 ]
 #else
 let gryphonLibDependencies: [Target.Dependency] = [
-	.product(name: "SwiftSyntax", package: "SwiftSyntax"),
-	.product(name: "SourceKittenFramework", package: "SourceKitten")
+    .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+    .product(name: "SourceKittenFramework", package: "SourceKitten")
 ]
 #endif
 
 let package = Package(
-	name: "Gryphon",
-	platforms: [
-        .macOS(.v12)
-		/* Linux */
-	],
-	products: [
-		.executable(name: "gryphon", targets: ["Gryphon"])
-	],
-	dependencies: [
-		swiftSyntaxPackage,
-		.package(
-			url: "https://github.com/jpsim/SourceKitten",
-			from: "0.31.1"),
-	],
-	targets: [
-		.target(
-			name: "GryphonLib",
-			dependencies: gryphonLibDependencies),
-		.target(
-			name: "Gryphon",
-			dependencies: ["GryphonLib"]),
-		.testTarget(
-			name: "GryphonLibTests",
-			dependencies: ["GryphonLib"])
-	],
-	swiftLanguageVersions: [.v5]
+    name: "Gryphon",
+    platforms: [
+        .macOS(.v10_13)
+        /* Linux */
+    ],
+    products: [
+        .executable(name: "gryphon", targets: ["Gryphon"])
+    ],
+    dependencies: [
+        swiftSyntaxPackage,
+        .package(
+            url: "https://github.com/jpsim/SourceKitten",
+                 .exact("0.31.1")
+        )
+    ],
+    targets: [
+        .target(
+            name: "GryphonLib",
+            dependencies: gryphonLibDependencies),
+        .target(
+            name: "Gryphon",
+            dependencies: ["GryphonLib"]),
+        .testTarget(
+            name: "GryphonLibTests",
+            dependencies: ["GryphonLib"])
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 //
@@ -73,7 +73,7 @@ let gryphonLibDependencies: [Target.Dependency] = [
 let package = Package(
 	name: "Gryphon",
 	platforms: [
-		.macOS(.v10_13)
+        .macOS(.v12)
 		/* Linux */
 	],
 	products: [

--- a/Sources/GryphonLib/GryphonSwiftLibrary.swift
+++ b/Sources/GryphonLib/GryphonSwiftLibrary.swift
@@ -356,6 +356,11 @@ public struct _ListSlice<Element>: Collection,
 		let array = list.array[range]
 		return try List<SegmentOfResult.Element>(array.flatMap(transform))
 	}
+    
+    // RangeReplaceableCollection
+    public func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C : Collection, Element == C.Element {
+        list.array[range].replaceSubrange(subrange, with: newElements)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Sources/GryphonLib/GryphonSwiftLibrary.swift
+++ b/Sources/GryphonLib/GryphonSwiftLibrary.swift
@@ -672,6 +672,11 @@ public class MutableList<Element>: List<Element>,
 	override public func drop(while predicate: (Element) throws -> Bool) rethrows -> List<Element> {
 		return try List(array.drop(while: predicate))
 	}
+    
+    // RangeReplaceableCollection
+    public func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C : Collection, Element == C.Element {
+        self.array.replaceSubrange(subrange, with: newElements)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Test files/Test cases/gryphonLibraries.swift
+++ b/Test files/Test cases/gryphonLibraries.swift
@@ -626,6 +626,11 @@ public class MutableList<Element>: List<Element>,
 	override public func drop(while predicate: (Element) throws -> Bool) rethrows -> List<Element> {
 		return try List(array.drop(while: predicate))
 	}
+    
+    // RangeReplaceableCollection
+    public func replaceSubrange<C>(_ subrange: Range<Index>, with newElements: C) where C : Collection, Element == C.Element {
+        self.array.replaceSubrange(subrange, with: newElements)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Test files/Test cases/gryphonLibraries.swift
+++ b/Test files/Test cases/gryphonLibraries.swift
@@ -335,6 +335,11 @@ public struct _ListSlice<Element>: Collection,
 		let array = list.array[range]
 		return try List<SegmentOfResult.Element>(array.flatMap(transform))
 	}
+    
+    // RangeReplaceableCollection
+    public func replaceSubrange<C>(_ subrange: Range<Int>, with newElements: C) where C : Collection, Element == C.Element {
+        list.array[range].replaceSubrange(subrange, with: newElements)
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
<!-- Thank you for your contribution to Gryphon! Remember it's OK to ask for help if you need it. -->

### What's in this pull request?
This pull request includes the necessary changes that enabled the Gryphon package to be built with Swift 5.7/Xcode 14. These changes have been discussed at #117 

I've also tested with the Release Candidate version of Xcode 14, release on September 7th

### Does this resolve an open issue?
It partially resolvers #117. It fixed the build erros the project were having on newer Xcode versions, but it doesn't fix the translation script issues

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [ ] You ran the unit tests and Bootstrapping tests for your platform.
  - [ ] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
  <!-- - [ ] Optional: if you're on macOS, you also ran the tests on a Docker container (it's OK if you didn't). -->
- [ ] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

