### PR TITLE
Fix error when trying to install on macOS 12.0 (Monterrey) or later

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -81,8 +81,10 @@ let package = Package(
 	],
 	dependencies: [
 		swiftSyntaxPackage,
-        .package(url: "https://github.com/jpsim/SourceKitten",
-                 .exact("0.31.1"))
+        .package(
+            url: "https://github.com/jpsim/SourceKitten",
+                 .exact("0.31.1")
+        )
 	],
 	targets: [
 		.target(

--- a/Package.swift
+++ b/Package.swift
@@ -81,9 +81,8 @@ let package = Package(
 	],
 	dependencies: [
 		swiftSyntaxPackage,
-		.package(
-			url: "https://github.com/jpsim/SourceKitten",
-			from: "0.31.1"),
+        .package(url: "https://github.com/jpsim/SourceKitten",
+                 .exact("0.31.1"))
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
### What's in this pull request?

This pull request fixes an error when attempting to install Gryphon on a Mac running macOS 12.0 (Monterrey) or later. This issue happened because the SourceKitten dependency [increased their target version to macOS 12.0](https://github.com/jpsim/SourceKitten/releases/tag/0.33.0), while the Gryphon project itself has remained with macOS 10.13. 

Since the `Package.swift` was configured to use the latest version up to the next major, upon running the `install` script, Gryphon tried to install the latest version of the dependency, which would fail because of the target version conflict. In order to fix this, I've set the Package file to use the exact last compatible version of SourceKitten

### Does this resolve an open issue?
Yes, it resolves the issue at #118 

### Checklist for submitting a pull request:

- [x] Your code builds without any errors or warnings (warnings when running `prepareForBootstrapTests.sh` are OK).
- [x] You ran the unit tests and Bootstrapping tests for your platform.
  - [ ] If you changed any `.kt` files in the `Test cases` folder, you also ran the Acceptance tests.
- [ ] You have added new tests that check your changes (if possible).
- [x] This pull request is targeting the `development` branch (if you're contributing code) or the `gh-pages` branch (if you're contributing to the website).

